### PR TITLE
Improve map performance

### DIFF
--- a/src/components/DataSourceMapSidebar.vue
+++ b/src/components/DataSourceMapSidebar.vue
@@ -85,19 +85,8 @@ onMounted(() => {
 async function setSidebarData(dataSourceMap) {
 	isSidebarUpdating.value = true;
 
-	props.data.forEach((source) => {
-		const index = sourcesInMapBounds.value.indexOf(source);
-		const isVisible = dataSourceMap
-			.getBounds()
-			.contains([source.lng, source.lat]);
-
-		if (isVisible && index === -1) {
-			sourcesInMapBounds.value.push(source);
-		} else if (!isVisible && index > -1) {
-			sourcesInMapBounds.value.splice(index, 1);
-		}
-	});
-	console.log("from query", props.map.querySourceFeatures("regular-markers"))
+	const mapBounds = dataSourceMap.getBounds()
+	sourcesInMapBounds.value = props.data.filter((source) => mapBounds.contains([source.lng, source.lat]))
 
 	getSideBarRenderDataFormatted(dataSourceMap);
 	isSidebarUpdating.value = false;

--- a/src/components/DataSourceMapSidebar.vue
+++ b/src/components/DataSourceMapSidebar.vue
@@ -97,6 +97,8 @@ async function setSidebarData(dataSourceMap) {
 			sourcesInMapBounds.value.splice(index, 1);
 		}
 	});
+	console.log("from query", props.map.querySourceFeatures("regular-markers"))
+
 	getSideBarRenderDataFormatted(dataSourceMap);
 	isSidebarUpdating.value = false;
 }


### PR DESCRIPTION
## Overview

This PR implements some of the performance improvements suggested in [this comment](https://github.com/Police-Data-Accessibility-Project/data-source-map/pull/16#issuecomment-2707042130) including:

1. Rendering markers more efficiently
2. Using clusters instead of markers at high zoom levels

## Demo

https://github.com/user-attachments/assets/c5d0bc93-812d-4fac-8d51-2cbd8697eefd

## Notes

### Clustering

I used Mapbox's default colors and styling for the clusters. Please feel free to suggest any style improvements.

Also, if the PDAP team would rather just use markers, I'm more than happy to switch back.

### Sidebar Filtering

One non-trivial part of the map's sluggishness that I didn't catch in my previous comment was the source filtering that happens in the sidebar. The issue there was the usage of the Javascript's [splice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) on every zoom change.

## Testing Instructions

Run the map locally and test the performance.

