### PR TITLE
feat: add details to d3 map

### DIFF
--- a/src/components/d3/DataSourceMapD3.vue
+++ b/src/components/d3/DataSourceMapD3.vue
@@ -72,8 +72,8 @@ const layers = ref({
 	stateBoundaries: {
 		data: statesGeoJSON,
 		visible: true,
-		minZoom: 3, // Same min zoom as counties
-		maxZoom: Infinity, // Same max zoom as counties
+		minZoom: 3,
+		maxZoom: Infinity,
 	},
 	countyOverlay: {
 		data: countiesGeoJSON,
@@ -222,7 +222,7 @@ function initMap() {
 				width.value - padding.left - padding.right,
 				height.value - padding.top - padding.bottom,
 			],
-			countiesGeoJSON,
+			layers.value.counties.data,
 		);
 
 	path.value = d3.geoPath().projection(projectionObj);
@@ -244,9 +244,6 @@ function initMap() {
 
 // Update the map with current data
 function updateMap() {
-	if (!countiesGeoJSON || !props.counties || props.counties.length === 0)
-		return;
-
 	// Clear previous map if any
 	svg.value.selectAll('*').remove();
 
@@ -293,7 +290,7 @@ function renderCountiesLayer(container) {
 	// Draw counties with choropleth coloring
 	countiesLayer
 		.selectAll('path')
-		.data(countiesGeoJSON.features)
+		.data(layers.value.counties.data.features)
 		.enter()
 		.append('path')
 		.attr('fill', (d) => {
@@ -369,7 +366,7 @@ function renderStateBoundariesLayer(container) {
 	// Draw state boundaries with no fill, just strokes
 	boundariesLayer
 		.selectAll('path')
-		.data(statesGeoJSON.features)
+		.data(layers.value.stateBoundaries.data.features)
 		.enter()
 		.append('path')
 		.attr('fill', 'none')
@@ -435,7 +432,7 @@ function renderStateOverlay(container) {
 		.attr(
 			'd',
 			path.value(
-				statesGeoJSON.features.find(
+				layers.value.stateOverlay.data.features.find(
 					(d) => d.properties.NAME === activeState.name,
 				),
 			),
@@ -457,7 +454,7 @@ function renderStateOverlay(container) {
 	overlayLayer
 		.selectAll('path.active-state-border')
 		.data([
-			statesGeoJSON.features.find(
+			layers.value.stateOverlay.data.features.find(
 				(d) => d.properties.NAME === activeState.name,
 			),
 		])
@@ -515,7 +512,7 @@ function renderCountyOverlay(container) {
 		.attr(
 			'd',
 			path.value(
-				countiesGeoJSON.features.find((d) => {
+				layers.value.countyOverlay.data.features.find((d) => {
 					const fips = d.properties.STATE + d.properties.COUNTY;
 					return fips === activeCounty.fips;
 				}),
@@ -538,7 +535,7 @@ function renderCountyOverlay(container) {
 	overlayLayer
 		.selectAll('path.active-county-border')
 		.data([
-			countiesGeoJSON.features.find((d) => {
+			layers.value.countyOverlay.data.features.find((d) => {
 				const fips = d.properties.STATE + d.properties.COUNTY;
 				return fips === activeCounty.fips;
 			}),
@@ -569,7 +566,7 @@ function renderStatesLayer(container) {
 	// Draw states with choropleth coloring
 	statesLayer
 		.selectAll('path')
-		.data(statesGeoJSON.features)
+		.data(layers.value.states.data.features)
 		.enter()
 		.append('path')
 		.attr('fill', (d) => {

--- a/src/components/d3/DataSourceMapD3.vue
+++ b/src/components/d3/DataSourceMapD3.vue
@@ -8,22 +8,36 @@
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
 import * as d3 from 'd3';
 import { scaleThreshold } from 'd3-scale';
-import _debounce from 'lodash/debounce';
+
+import { FILL_COLORS, handleTheme } from './utils/theme';
+import {
+	setupZoom,
+	updateLayerVisibility,
+	addZoomControls,
+	updateIconSize,
+	updateZoomLevel,
+	handleOverlaysOnZoom,
+} from './utils/zoom';
+import { renderStatesLayer } from './renderers/states';
+import { renderStateOverlay } from './renderers/state-overlay';
+import { renderCountiesLayer } from './renderers/counties';
+import { renderStateBoundariesLayer } from './renderers/state-boundaries';
+import { renderCountyOverlay } from './renderers/county-overlay';
+import { renderLocalityMarkers } from './renderers/localities';
+import { createTooltip } from './renderers/tooltip';
+import { createLegend } from './renderers/legend';
+import {
+	handleStateClick,
+	handleCountyClick,
+	handleLocalityClick,
+	resetZoom,
+} from './utils/interaction';
+import { updateOverlays } from './utils/overlay';
+// import { createOverlayDeps } from './utils/createOverlayDeps';
+
 import countiesGeoJSON from '../../util/geoJSON/counties.json';
 import statesGeoJSON from '../../util/geoJSON/states.json';
 
-const FILL_COLORS = [
-	// 'rgb(247, 247, 248)',
-	// 'rgb(242, 240, 243)',
-	'rgb(232, 226, 232)',
-	'rgb(212, 204, 213)',
-	'rgb(187, 171, 187)',
-	'rgb(163, 144, 164)',
-	'rgb(140, 118, 140)',
-	'rgb(117, 97, 116)',
-	'rgb(98, 82, 96)',
-	'rgb(80, 66, 79)',
-];
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 50;
 // Apply a small correction to latitude values (to compensate for albers proj)
@@ -130,31 +144,6 @@ const stateDataMap = computed(() => {
 	return map;
 });
 
-// Computed property to determine the selected location level
-// const selectedLocationLevel = computed(() => {
-// 	if (activeLocationStack.value.length === 0) return null;
-// 	const activeLocation =
-// 		activeLocationStack.value[activeLocationStack.value.length - 1];
-// 	return activeLocation.fips ? 'county' : 'state';
-// });
-
-// Computed property for color scale domain
-// const colorDomain = computed(() => {
-// 	if (!countyDataMap.value || Object.keys(countyDataMap.value).length === 0) {
-// 		return [1, 10]; // Default domain starting at 1
-// 	}
-
-// 	const values = Object.values(countyDataMap.value).filter(
-// 		(val) => val !== undefined && val > 0, // Only include values > 0
-// 	);
-// 	if (values.length === 0) {
-// 		return [1, 10];
-// 	}
-
-// 	const max = Math.max(...values);
-// 	return [1, max]; // Start at 1 instead of 0
-// });
-
 // Initialize map when component is mounted
 onMounted(() => {
 	currentTheme.value = handleTheme();
@@ -180,8 +169,23 @@ watch(
 );
 watch(
 	() => activeLocationStack.value,
-	(newStack) => {
-		console.debug({ newStack });
+	() => {
+		// Update overlays immediately when activeLocationStack changes
+		const overlayDeps = {
+			svg: svg.value,
+			activeLocationStack: activeLocationStack.value,
+			layers: layers.value,
+			path: path.value,
+			width: width.value,
+			height: height.value,
+			props,
+			currentTheme: currentTheme.value,
+		};
+		updateOverlays({
+			renderStateOverlay,
+			renderCountyOverlay,
+			deps: overlayDeps,
+		});
 	},
 	{ deep: true },
 );
@@ -210,25 +214,7 @@ function initMap() {
 		.attr('viewBox', `0 0 ${width.value} ${height.value}`)
 		.attr('preserveAspectRatio', 'xMidYMid meet');
 
-	// Create tooltip
-	tooltip.value = d3
-		.select('body')
-		.append('div')
-		.attr('class', 'tooltip')
-		.style('opacity', 0)
-		.style('position', 'absolute')
-		.style('background-color', currentTheme.value.theme.tooltip.backgroundColor)
-		.style('color', currentTheme.value.theme.tooltip.textColor)
-		.style(
-			'border',
-			`1px solid ${currentTheme.value.theme.tooltip.borderColor}`,
-		)
-		.style('padding', '10px')
-		.style('border-radius', '3px')
-		.style('pointer-events', 'none')
-		.style('z-index', 1000)
-		.style('font-size', '12px')
-		.style('box-shadow', '0 2px 5px rgba(0,0,0,0.2)');
+	createTooltip(tooltip, currentTheme);
 
 	const padding = { top: 10, right: 10, bottom: 80, left: 10 };
 	projection.value = d3
@@ -253,10 +239,175 @@ function initMap() {
 		.range(FILL_COLORS); // Use all custom colors
 
 	// Setup zoom behavior
-	setupZoom();
+	setupZoom({
+		svg: svg.value,
+		MIN_ZOOM,
+		MAX_ZOOM,
+		handleZoom: (event) => {
+			// Update overlay visibility before overwriting current zoom
+			activeLocationStack.value = handleOverlaysOnZoom({
+				event,
+				currentZoom: currentZoom.value,
+				layers: layers.value,
+				activeLocationStack: activeLocationStack.value,
+				props,
+				svg: svg.value,
+			});
+
+			// Store current zoom transform
+			zoomTransform.value = event.transform;
+			currentZoom.value = event.transform.k;
+
+			// Apply transform to all layers
+			const mapContainer = svg.value.select('.map-container');
+			if (!mapContainer.empty()) {
+				mapContainer.attr('transform', event.transform);
+			} else {
+				console.error('Map container not found for zoom transform');
+			}
+
+			// Update layer visibility based on zoom level
+			updateLayerVisibility({
+				layers: layers.value,
+				currentZoom: currentZoom.value,
+				svg: svg.value,
+				createLegend: () => createLegend(mapDeps.value),
+			});
+
+			updateIconSize(currentZoom.value, MAX_ZOOM);
+			updateZoomLevel(currentZoom.value, MAX_ZOOM);
+		},
+	});
 
 	updateMap();
 }
+
+// Create a computed property for the master dependencies object
+// This will be passed to all render functions and handlers
+const mapDeps = computed(() => {
+	// Helper function to create overlay deps without circular reference
+	const getOverlayDeps = () => ({
+		svg: svg.value,
+		activeLocationStack: activeLocationStack.value,
+		layers: layers.value,
+		path: path.value,
+		width: width.value,
+		height: height.value,
+		props,
+		currentTheme: currentTheme.value,
+	});
+
+	return {
+		// Core map properties
+		svg: svg.value,
+		width: width.value,
+		height: height.value,
+		path: path.value,
+		projection: projection.value,
+		tooltip: tooltip.value,
+
+		// Data and state
+		props,
+		layers: layers.value,
+		activeLocationStack: activeLocationStack.value,
+		currentZoom: currentZoom.value,
+		zoomTransform: zoomTransform.value,
+
+		// Color scales and theme
+		countyColorScale: countyColorScale.value,
+		stateColorScale: stateColorScale.value,
+		currentTheme: currentTheme.value,
+
+		// Data maps
+		countyDataMap: countyDataMap.value,
+		stateDataMap: stateDataMap.value,
+
+		// Constants
+		LAT_CORRECTION,
+		MIN_ZOOM,
+		MAX_ZOOM,
+		FILL_COLORS,
+		countyColorBreakpoints,
+		stateColorBreakpoints,
+
+		// Handler functions
+		handleStateClick: (event, d) => {
+			activeLocationStack.value = handleStateClick({
+				event,
+				d,
+				path: path.value,
+				width: width.value,
+				height: height.value,
+				props,
+				activeLocationStack: [...activeLocationStack.value],
+				layers: layers.value,
+				svg: svg.value,
+				updateOverlays: () =>
+					updateOverlays({
+						renderStateOverlay,
+						renderCountyOverlay,
+						deps: getOverlayDeps(),
+					}),
+			});
+		},
+
+		handleCountyClick: (event, d) => {
+			activeLocationStack.value = handleCountyClick({
+				event,
+				d,
+				path: path.value,
+				width: width.value,
+				height: height.value,
+				props,
+				activeLocationStack: [...activeLocationStack.value],
+				layers: layers.value,
+				svg: svg.value,
+				updateOverlays: () =>
+					updateOverlays({
+						renderStateOverlay,
+						renderCountyOverlay,
+						deps: getOverlayDeps(),
+					}),
+			});
+		},
+
+		handleLocalityClick: (event, locality) => {
+			activeLocationStack.value = handleLocalityClick({
+				event,
+				locality,
+				projection: projection.value,
+				width: width.value,
+				height: height.value,
+				activeLocationStack: [...activeLocationStack.value],
+				updateOverlays: () =>
+					updateOverlays({
+						renderStateOverlay,
+						renderCountyOverlay,
+						deps: getOverlayDeps(),
+					}),
+				svg: svg.value,
+				LAT_CORRECTION,
+			});
+		},
+
+		resetZoom: () => {
+			activeLocationStack.value = resetZoom({
+				activeLocationStack: [...activeLocationStack.value],
+				layers: layers.value,
+				svg: svg.value,
+			});
+		},
+
+		// Utility functions
+		updateOverlays: () => {
+			return updateOverlays({
+				renderStateOverlay,
+				renderCountyOverlay,
+				deps: getOverlayDeps(),
+			});
+		},
+	};
+});
 
 // Update the map with current data
 function updateMap() {
@@ -270,1122 +421,37 @@ function updateMap() {
 		mapContainer.attr('transform', zoomTransform.value);
 	}
 
+	const deps = mapDeps.value;
+
 	// Render layers in the correct order:
-	// 1. Counties (bottom layer)
-	// 2. State boundaries (middle layer, only outlines)
-	// 3. States (top layer, full choropleth)
-	// 4. Locality markers (point features)
-	// 5. Overlay layers (top-most, for highlighting selected features)
-	renderStatesLayer(mapContainer);
-	renderStateOverlay(mapContainer);
-	renderCountiesLayer(mapContainer);
-	renderStateBoundariesLayer(mapContainer);
-	renderCountyOverlay(mapContainer);
+	renderStatesLayer(mapContainer, deps);
+	renderCountiesLayer(mapContainer, deps);
+	renderStateBoundariesLayer(mapContainer, deps);
 
-	// Add overlay layers on top
+	renderStateOverlay(mapContainer, deps);
+	renderCountyOverlay(mapContainer, deps);
 
-	// Localities
-	renderLocalityMarkers(mapContainer);
+	renderLocalityMarkers(mapContainer, deps);
 
 	// Update layer visibility based on current zoom
-	updateLayerVisibility();
+	updateLayerVisibility({
+		layers: layers.value,
+		currentZoom: currentZoom.value,
+		svg: svg.value,
+		createLegend: () => createLegend(deps),
+	});
 
 	// Add zoom controls
-	addZoomControls();
+	addZoomControls({
+		svg: svg.value,
+		width: width.value,
+		resetZoom: deps.resetZoom,
+	});
 
 	// Add legend
-	createLegend();
+	createLegend(deps);
 
 	console.log('Map updated with layers:', Object.keys(layers.value));
-}
-
-// Render counties layer
-function renderCountiesLayer(container) {
-	// Always create the layer, but control visibility with CSS
-	const countiesLayer = container
-		.append('g')
-		.attr('class', 'layer counties-layer')
-		.style('display', layers.value.counties.visible ? 'block' : 'none');
-
-	// Draw counties with choropleth coloring
-	countiesLayer
-		.selectAll('path')
-		.data(layers.value.counties.data.features)
-		.enter()
-		.append('path')
-		.attr('fill', (d) => {
-			// Use STATE + COUNTY as the FIPS code
-			const props = d.properties;
-			let value;
-
-			if (props.STATE && props.COUNTY) {
-				const fips = props.STATE + props.COUNTY;
-				value = countyDataMap.value[fips];
-			}
-
-			// Only color counties with at least 1 source
-			return value !== undefined && value > 0
-				? countyColorScale.value(value)
-				: currentTheme.value.theme.map.noDataColor; // Theme-appropriate color for counties with no data
-		})
-		.attr('d', path.value)
-		.attr('stroke', currentTheme.value.theme.map.strokeColor) // Theme-appropriate stroke for county boundaries
-		.attr('stroke-width', 0.2)
-		.attr('cursor', 'pointer') // Show pointer cursor on counties too
-		.on('click', function (event, d) {
-			console.log('County clicked:', d.properties.NAME || d.properties.COUNTY);
-			event.stopPropagation(); // Stop event bubbling
-			handleCountyClick(event, d);
-		})
-		.on('mouseover', (event, d) => {
-			// Use STATE + COUNTY as the FIPS code
-			let fips;
-			if (d.properties.STATE && d.properties.COUNTY) {
-				fips = d.properties.STATE + d.properties.COUNTY;
-			}
-
-			// Find the county using the FIPS code
-			const county = props.counties.find((c) => c.fips == fips);
-
-			if (county) {
-				tooltip.value
-					.style('opacity', 0.9)
-					.html(
-						`
-            <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
-              ${county.name}, ${county.state_iso}
-            </div>
-            <div style="margin-bottom:3px;">FIPS: ${county.fips}</div>
-            <div style="font-weight:bold; font-size:13px;">
-              Sources: ${county.source_count}
-            </div>
-          `,
-					)
-					.style('left', event.pageX + 10 + 'px')
-					.style('top', event.pageY - 28 + 'px');
-			}
-		})
-		.on('mouseout', () => {
-			tooltip.value.style('opacity', 0);
-		});
-
-	console.log(
-		'Counties layer rendered, visible:',
-		layers.value.counties.visible,
-	);
-}
-
-// Render state boundaries layer (outlines only)
-function renderStateBoundariesLayer(container) {
-	// Always create the layer, but control visibility with CSS
-	const boundariesLayer = container
-		.append('g')
-		.attr('class', 'layer stateBoundaries-layer')
-		.style('display', layers.value.stateBoundaries.visible ? 'block' : 'none');
-
-	// Draw state boundaries with no fill, just strokes
-	boundariesLayer
-		.selectAll('path')
-		.data(layers.value.stateBoundaries.data.features)
-		.enter()
-		.append('path')
-		.attr('fill', 'none')
-		.attr('stroke', currentTheme.value.theme.map.stateBorderColor)
-		.attr('d', path.value);
-
-	console.log(
-		'State boundaries layer rendered, visible:',
-		layers.value.stateBoundaries.visible,
-	);
-}
-
-// Render state overlay layer
-function renderStateOverlay(container) {
-	if (
-		!layers.value.stateOverlay.visible ||
-		activeLocationStack.value.length === 0
-	)
-		return;
-
-	const activeState = props.states.find(
-		(state) =>
-			state.state_iso ===
-			activeLocationStack.value[activeLocationStack.value.length - 1].data
-				.state_iso,
-	);
-
-	console.debug({
-		activeState,
-		activeLocationStack: activeLocationStack.value,
-	});
-
-	if (!activeState) return;
-
-	// Remove any existing overlay first to prevent duplicates
-	svg.value.select('.stateOverlay-layer').remove();
-
-	const overlayLayer = container
-		.append('g')
-		.attr('class', 'layer stateOverlay-layer')
-		.style('display', layers.value.stateOverlay.visible ? 'block' : 'none');
-
-	// Create a mask for the active state
-	const maskId = `mask-state-${Date.now()}`; // Use timestamp to ensure uniqueness
-
-	// Add a mask definition
-	const defs = overlayLayer.append('defs');
-	const mask = defs.append('mask').attr('id', maskId);
-
-	// Add a white background to the mask (white = visible area)
-	mask
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 0)
-		.attr('width', width.value)
-		.attr('height', height.value)
-		.attr('fill', 'white');
-
-	// Add the state shape to the mask in black (black = invisible area)
-	mask
-		.append('path')
-		.attr(
-			'd',
-			path.value(
-				layers.value.stateOverlay.data.features.find(
-					(d) => d.properties.NAME === activeState.name,
-				),
-			),
-		)
-		.attr('fill', 'black');
-
-	// Add a semi-transparent background that covers everything EXCEPT the active state
-	overlayLayer
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 0)
-		.attr('width', width.value)
-		.attr('height', height.value)
-		.attr('fill', currentTheme.value.theme.map.overlayColor)
-		.attr('mask', `url(#${maskId})`)
-		.attr('pointer-events', 'none'); // Allow clicks to pass through
-
-	// Add a stroke around the active state
-	overlayLayer
-		.selectAll('path.active-state-border')
-		.data([
-			layers.value.stateOverlay.data.features.find(
-				(d) => d.properties.NAME === activeState.name,
-			),
-		])
-		.enter()
-		.append('path')
-		.attr('class', 'active-state-border')
-		.attr('fill', 'none') // No fill, just stroke
-		.attr('stroke', currentTheme.value.theme.map.stateBorderColor)
-		.attr('d', path.value)
-		.attr('pointer-events', 'none'); // Allow clicks to pass through
-
-	console.log('State overlay layer rendered, active state:', activeState.name);
-}
-
-// Render county overlay layer
-function renderCountyOverlay(container) {
-	if (
-		!layers.value.countyOverlay.visible ||
-		activeLocationStack.value.length === 0
-	)
-		return;
-
-	const activeLocation =
-		activeLocationStack.value[activeLocationStack.value.length - 1];
-	if (activeLocation.type === 'state') return;
-
-	console.debug({ activeLocation });
-
-	// Remove any existing overlay first to prevent duplicates
-	svg.value.select('.countyOverlay-layer').remove();
-
-	const overlayLayer = container
-		.append('g')
-		.attr('class', 'layer countyOverlay-layer')
-		.style('display', layers.value.countyOverlay.visible ? 'block' : 'none');
-
-	// Create a mask for the active county
-	const maskId = `mask-county-${Date.now()}`; // Use timestamp to ensure uniqueness
-
-	// Add a mask definition
-	const defs = overlayLayer.append('defs');
-	const mask = defs.append('mask').attr('id', maskId);
-
-	// Add a white background to the mask (white = visible area)
-	mask
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 0)
-		.attr('width', width.value)
-		.attr('height', height.value)
-		.attr('fill', 'white');
-
-	// Add the county shape to the mask in black (black = invisible area)
-	mask
-		.append('path')
-		.attr(
-			'd',
-			path.value(
-				layers.value.countyOverlay.data.features.find((d) => {
-					const fips = d.properties.STATE + d.properties.COUNTY;
-					return (
-						fips === (activeLocation.fips || activeLocation.data.county_fips)
-					);
-				}),
-			),
-		)
-		.attr('fill', 'black');
-
-	// Add a semi-transparent background that covers everything EXCEPT the active county
-	overlayLayer
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 0)
-		.attr('width', width.value)
-		.attr('height', height.value)
-		.attr('fill', currentTheme.value.theme.map.overlayColor)
-		.attr('mask', `url(#${maskId})`)
-		.attr('pointer-events', 'none'); // Allow clicks to pass through
-
-	// Add a stroke around the active county
-	overlayLayer
-		.selectAll('path.active-county-border')
-		.data([
-			layers.value.countyOverlay.data.features.find((d) => {
-				const fips = d.properties.STATE + d.properties.COUNTY;
-				return fips === activeLocation.fips;
-			}),
-		])
-		.enter()
-		.append('path')
-		.attr('class', 'active-county-border')
-		.attr('fill', 'none')
-		.attr('stroke', currentTheme.value.theme.map.strokeColor)
-		.attr('stroke-width', 0.5)
-		.attr('d', path.value)
-		.attr('pointer-events', 'none');
-}
-
-// Function to render locality markers
-// Function to render locality markers
-function renderLocalityMarkers(container) {
-	console.log('Rendering locality markers, count:', props.localities.length);
-	console.log('Current zoom level:', currentZoom.value);
-
-	// Skip if no localities
-	if (!props.localities || props.localities.length === 0) {
-		console.log('No localities to render');
-		return;
-	}
-
-	// Create a layer for locality markers
-	const localitiesLayer = container
-		.append('g')
-		.attr('class', 'layer localities-layer')
-		.style('display', layers.value.localities.visible ? 'block' : 'none');
-
-	// Create GeoJSON points for each locality
-	const localityGeoJSON = {
-		type: 'FeatureCollection',
-		features: props.localities
-			.map((locality) => {
-				if (
-					locality.coordinates &&
-					locality.coordinates.lat &&
-					locality.coordinates.lng
-				) {
-					const correctedLat = locality.coordinates.lat + LAT_CORRECTION;
-
-					return {
-						type: 'Feature',
-						properties: locality,
-						geometry: {
-							type: 'Point',
-							// GeoJSON format is [longitude, latitude]
-							coordinates: [locality.coordinates.lng, correctedLat],
-						},
-					};
-				}
-				return null;
-			})
-			.filter(Boolean), // Remove null entries
-	};
-
-	console.log('Created GeoJSON for localities:', localityGeoJSON);
-
-	// Calculate marker size based on zoom level
-	const iconSize = 3;
-
-	// Add markers using path generator directly
-	const markers = localitiesLayer
-		.selectAll('.locality-marker')
-		.data(localityGeoJSON.features)
-		.enter()
-		.append('g')
-		.attr('class', 'locality-marker')
-		.attr('transform', (d) => {
-			// Project the coordinates to screen space
-			console.log('Projecting coordinates:', d.geometry.coordinates);
-
-			// Make sure we have valid coordinates before projecting
-			if (!d.geometry.coordinates || d.geometry.coordinates.length !== 2) {
-				console.error('Invalid coordinates:', d.geometry.coordinates);
-				return null;
-			}
-
-			// Use path.centroid instead of direct projection for more reliable results
-			const centroid = path.value.centroid(d);
-			if (
-				centroid &&
-				centroid.length === 2 &&
-				!isNaN(centroid[0]) &&
-				!isNaN(centroid[1])
-			) {
-				return `translate(${centroid[0]}, ${centroid[1]})`;
-			}
-
-			return null;
-		});
-
-	// Add Font Awesome icon as text element
-	markers
-		.append('text')
-		.attr(
-			'class',
-			(d) =>
-				`fa locality-marker ${d.properties.source_count ? 'has-sources' : 'no-sources'}`,
-		)
-		.attr('font-family', 'FontAwesome')
-		.attr('text-anchor', 'middle')
-		.attr('dominant-baseline', 'central')
-		.attr('y', -2) // Adjust position slightly
-		.attr('fill', '#ffffff')
-		.attr('cursor', 'pointer')
-		.text('\uf041'); // Font Awesome map marker unicode
-
-	// Add click and hover handlers
-	markers
-		.on('click', (event, d) => {
-			event.stopPropagation();
-			handleLocalityClick(event, d.properties);
-		})
-		.on('mouseover', function (event, d) {
-			const locality = d.properties;
-			// Show tooltip with locality information
-			tooltip.value
-				.style('opacity', 0.9)
-				.html(
-					`
-          <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
-            ${locality.name}
-          </div>
-          <div style="margin-bottom:3px;">
-            ${locality.county_name ? locality.county_name + ' County' : ''}
-          </div>
-          <div style="font-weight:bold; font-size:13px;">
-            Sources: ${locality.source_count}
-          </div>
-        `,
-				)
-				.style('left', event.pageX + 10 + 'px')
-				.style('top', event.pageY - 28 + 'px');
-
-			// Highlight the marker
-			d3.select(this)
-				.select('text')
-				.attr('font-size', `${iconSize * 1.25}px`);
-		})
-		.on('mouseout', function () {
-			// Hide tooltip
-			tooltip.value.style('opacity', 0);
-
-			// Reset marker style
-			d3.select(this).select('text').attr('font-size', `${iconSize}px`);
-		});
-
-	console.log('Localities layer rendered with', markers.size(), 'markers');
-}
-
-// Handle locality marker click
-function handleLocalityClick(event, locality) {
-	console.log('Locality clicked:', locality.name);
-	const LAT_CORRECTION = -0.05;
-	const correctedLat = locality.coordinates.lat + LAT_CORRECTION;
-
-	// Convert lat/lng to pixel coordinates
-	const [x, y] = projection.value([locality.coordinates.lng, correctedLat]);
-
-	const scale = 30;
-
-	const translate = [width.value / 2 - scale * x, height.value / 2 - scale * y];
-
-	// Add locality to the active location stack
-	activeLocationStack.value.push({
-		type: 'locality',
-		name: locality.name,
-		data: locality,
-		fips: locality.county_fips,
-	});
-
-	updateOverlays();
-
-	// Get the stored zoom behavior
-	const zoom = svg.value.__zoom__ || d3.zoom();
-
-	// Animate zoom transition
-	svg.value
-		.transition()
-		.duration(750)
-		.call(
-			zoom.transform,
-			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
-		);
-}
-
-// Render states layer
-function renderStatesLayer(container) {
-	// Always create the layer, but control visibility with CSS
-	const statesLayer = container
-		.append('g')
-		.attr('class', 'layer states-layer')
-		.style('display', layers.value.states.visible ? 'block' : 'none');
-
-	// Draw states with choropleth coloring
-	statesLayer
-		.selectAll('path')
-		.data(layers.value.states.data.features)
-		.enter()
-		.append('path')
-		.attr('fill', (d) => {
-			// Use state name to look up data
-			const stateName = d.properties.NAME;
-			const value = stateDataMap.value[stateName];
-
-			// Only color states with at least 1 source
-			return value !== undefined && value > 0
-				? stateColorScale.value(value)
-				: currentTheme.value.theme.map.noDataColor; // Theme-appropriate color for states with no data
-		})
-		.attr('stroke', currentTheme.value.theme.map.stateBorderColor)
-		.attr('stroke-width', 0.5)
-		.attr('d', path.value)
-		.attr('cursor', 'pointer')
-		.on('click', function (event, d) {
-			event.stopPropagation(); // Stop event bubbling
-			handleStateClick(event, d);
-		})
-		.on('mouseover', (event, d) => {
-			// Find the state using the name
-			const stateName = d.properties.NAME;
-			const state = props.states.find((s) => s.name === stateName);
-
-			if (state) {
-				tooltip.value
-					.style('opacity', 0.9)
-					.html(
-						`
-            <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
-              ${state.name}
-            </div>
-            <div style="font-weight:bold; font-size:13px;">
-              Sources: ${state.source_count}
-            </div>
-          `,
-					)
-					.style('left', event.pageX + 10 + 'px')
-					.style('top', event.pageY - 28 + 'px');
-			}
-		})
-		.on('mouseout', () => {
-			tooltip.value.style('opacity', 0);
-		});
-}
-
-// Create a simple legend for the map
-function createLegend() {
-	// Determine which layer is visible
-	const visibleLayer = layers.value.counties.visible ? 'counties' : 'states';
-
-	// Use the appropriate color breakpoints based on visible layer
-	const breakpoints =
-		visibleLayer === 'counties'
-			? countyColorBreakpoints
-			: stateColorBreakpoints;
-
-	// Use the appropriate color scale
-	// const activeColorScale =
-	// 	visibleLayer === 'counties'
-	// 		? countyColorScale.value
-	// 		: stateColorScale.value;
-
-	// Create legend dimensions
-	const legendWidth = 200;
-	const legendHeight = 30;
-
-	// Position in bottom-right corner with offset to avoid Florida
-	const legendX = width.value - legendWidth - 40;
-	const legendY = height.value - legendHeight - 40;
-
-	// Add more space for the "No data" indicator
-	const noDataX = 10;
-	const noDataY = legendHeight + 15;
-
-	// Create legend group
-	const legend = svg.value
-		.append('g')
-		.attr('class', 'legend')
-		.attr('transform', `translate(${legendX}, ${legendY})`);
-
-	// Add background with theme-appropriate color and border
-	legend
-		.append('rect')
-		.attr('width', legendWidth + 20) // Make wider to include padding
-		.attr('height', legendHeight + 60) // Make taller to include title and "No data" below
-		.attr('x', -10)
-		.attr('y', -25) // Extend upward for title
-		.attr('fill', currentTheme.value.theme.legend.backgroundColor)
-		.attr('stroke', currentTheme.value.theme.legend.textColor)
-		.attr('stroke-width', 0.5)
-		.attr('stroke-opacity', 0.3)
-		.attr('rx', 3)
-		.attr('ry', 3);
-
-	// Create color rectangles for the gradient
-	FILL_COLORS.forEach((color, i) => {
-		legend
-			.append('rect')
-			.attr('x', i * (legendWidth / FILL_COLORS.length))
-			.attr('width', legendWidth / FILL_COLORS.length)
-			.attr('height', 20)
-			.attr('fill', color);
-	});
-
-	// Add text labels for min and max
-	legend
-		.append('text')
-		.attr('x', 0)
-		.attr('y', 35)
-		.attr('text-anchor', 'start')
-		.attr('font-size', '10px')
-		.attr('fill', currentTheme.value.theme.legend.textColor)
-		.text(`${Math.min(...breakpoints)}`);
-
-	legend
-		.append('text')
-		.attr('x', legendWidth)
-		.attr('y', 35)
-		.attr('text-anchor', 'end')
-		.attr('font-size', '10px')
-		.attr('fill', currentTheme.value.theme.legend.textColor)
-		.text(`${Math.max(...breakpoints)}+`);
-
-	// Add title based on visible layer
-	const title =
-		visibleLayer === 'counties' ? 'County Data Sources' : 'State Data Sources';
-	legend
-		.append('text')
-		.attr('x', legendWidth / 2)
-		.attr('y', -10)
-		.attr('text-anchor', 'middle')
-		.attr('font-size', '12px')
-		.attr('font-weight', 'bold')
-		.attr('fill', currentTheme.value.theme.legend.textColor)
-		.text(title);
-
-	// Add "No data" indicator below the gradient
-	legend
-		.append('rect')
-		.attr('x', noDataX)
-		.attr('y', noDataY)
-		.attr('width', 10)
-		.attr('height', 10)
-		.attr('fill', currentTheme.value.theme.legend.noDataColor);
-
-	legend
-		.append('text')
-		.attr('x', noDataX + 15)
-		.attr('y', noDataY + 9) // Align with the square
-		.attr('text-anchor', 'start')
-		.attr('font-size', '9px')
-		.attr('fill', currentTheme.value.theme.legend.textColor)
-		.text('No data');
-}
-
-// Setup zoom behavior
-function setupZoom() {
-	// Create zoom behavior
-	const zoom = d3
-		.zoom()
-		.scaleExtent([MIN_ZOOM, MAX_ZOOM]) // Min/max zoom levels
-		.on('zoom', handleZoom);
-
-	// Apply zoom to SVG
-	svg.value.call(zoom);
-
-	// Store the zoom behavior for later use
-	svg.value.__zoom__ = zoom;
-
-	// Initialize with no zoom
-	svg.value.call(zoom.transform, d3.zoomIdentity);
-}
-
-const updateIconSize = _debounce(
-	(zoomLevel) => {
-		// Calculate icon size: 4px at zoom 1, decreasing to 1px at zoom 22+
-		const minSize = 0.75;
-		const maxSize = 3;
-		const maxZoomRange = MAX_ZOOM / 2.3;
-
-		// Calculate size based on zoom level (inverse relationship)
-		let iconSize;
-		if (zoomLevel >= maxZoomRange) {
-			iconSize = minSize;
-		} else {
-			// Linear interpolation between maxSize and minSize
-			iconSize =
-				maxSize - ((zoomLevel - 1) / (maxZoomRange - 1)) * (maxSize - minSize);
-		}
-
-		// Round to 2 decimal places
-		iconSize = Math.round(iconSize * 100) / 100;
-
-		// Set the CSS variable on the container
-		document.documentElement.style.setProperty('--icon-size', `${iconSize}px`);
-	},
-	100,
-	{ leading: true, trailing: true },
-);
-const updateZoomLevel = _debounce(
-	(zoomLevel) => {
-		const minSize = 0;
-		const maxSize = 1;
-
-		// Calculate size based on zoom level (inverse relationship)
-		let zoomInversion;
-		if (zoomLevel >= MAX_ZOOM) {
-			zoomInversion = minSize;
-		} else {
-			// Linear interpolation between maxSize and minSize
-			zoomInversion =
-				maxSize - ((zoomLevel - 1) / (MAX_ZOOM - 1)) * (maxSize - minSize);
-		}
-
-		// Round to 2 decimal places
-		zoomInversion = Math.round(zoomInversion * 100) / 100;
-
-		// Set the CSS variable on the container
-		document.documentElement.style.setProperty(
-			'--zoom-inversion',
-			zoomInversion,
-		);
-	},
-	100,
-	{ leading: true, trailing: true },
-);
-
-// Handle zoom events
-function handleZoom(event) {
-	// Update overlay visibility before overwriting current zoom
-	handleOverlaysOnZoom(event, currentZoom.value);
-
-	// Store current zoom transform
-	zoomTransform.value = event.transform;
-	currentZoom.value = event.transform.k;
-
-	// Apply transform to all layers
-	const mapContainer = svg.value.select('.map-container');
-	if (!mapContainer.empty()) {
-		mapContainer.attr('transform', event.transform);
-	} else {
-		console.error('Map container not found for zoom transform');
-	}
-
-	// Update layer visibility based on zoom level
-	updateLayerVisibility();
-	updateIconSize(currentZoom.value);
-	updateZoomLevel(currentZoom.value);
-}
-
-function handleOverlaysOnZoom(event, currentZoom) {
-	if (event.transform.k < currentZoom) {
-		const COUNTY_THRESHOLD = 5.25;
-		const STATE_THRESHOLD = 1.25;
-
-		// County overlay
-		if (
-			!!layers.value.countyOverlay.visible &&
-			event.transform.k < COUNTY_THRESHOLD
-		) {
-			layers.value.countyOverlay.visible = false;
-
-			if (
-				['fips', 'county_fips'].some(
-					(s) =>
-						s in
-						(activeLocationStack.value[activeLocationStack.value.length - 1] ??
-							{}),
-				)
-			) {
-				const stateIndex = activeLocationStack.value.findLastIndex(
-					(loc) => loc.type === 'state',
-				);
-				const inferredState = props.states.find(
-					(state) =>
-						state.state_iso ===
-						activeLocationStack.value[activeLocationStack.value.length - 1].data
-							.state_iso,
-				);
-
-				activeLocationStack.value = activeLocationStack.value
-					.slice(0, stateIndex + 1)
-					.concat([
-						{
-							type: 'state',
-							name: inferredState.name,
-							data: inferredState,
-						},
-					]);
-			}
-
-			// Remove overlay layers from DOM
-			svg.value.select('.countyOverlay-layer').remove();
-		}
-
-		// State overlay
-		if (
-			!!layers.value.stateOverlay.visible &&
-			event.transform.k < STATE_THRESHOLD
-		) {
-			// Update visibility
-			layers.value.stateOverlay.visible = false;
-			layers.value.countyOverlay.visible = false;
-
-			// Remove overlay layers from DOM
-			svg.value.select('.stateOverlay-layer').remove();
-			svg.value.select('.countyOverlay-layer').remove();
-
-			// Clear the active location stack since we're zooming out
-			activeLocationStack.value = [];
-		}
-	}
-}
-
-// Update layer visibility based on zoom level
-function updateLayerVisibility() {
-	// Track if visibility changed
-	let visibilityChanged = false;
-	// const previousVisibility = {
-	// 	counties: layers.value.counties.visible,
-	// 	states: layers.value.states.visible,
-	// };
-
-	// Show/hide layers based on zoom level
-	Object.keys(layers.value).forEach((layerName) => {
-		const layer = layers.value[layerName];
-		const shouldBeVisible =
-			currentZoom.value >= layer.minZoom && currentZoom.value <= layer.maxZoom;
-
-		// Check if visibility changed
-		if (layer.visible !== shouldBeVisible) {
-			visibilityChanged = true;
-		}
-
-		// Update visibility state
-		layer.visible = shouldBeVisible;
-
-		// Apply visibility to DOM
-		const layerElement = svg.value.select(`.${layerName}-layer`);
-		if (!layerElement.empty()) {
-			layerElement.style('display', shouldBeVisible ? 'block' : 'none');
-		}
-	});
-
-	// Log current zoom level and layer visibility
-	// console.log('Current zoom:', currentZoom.value, 'Layers:', {
-	// 	counties: layers.value.counties.visible,
-	// 	states: layers.value.states.visible,
-	// });
-
-	// Update legend if layer visibility changed
-	if (visibilityChanged) {
-		// Remove existing legend
-		svg.value.select('.legend').remove();
-		// Create new legend with appropriate scale
-		createLegend();
-	}
-}
-
-// Handle state click to zoom
-function handleStateClick(event, d) {
-	event.stopPropagation();
-
-	const bounds = path.value.bounds(d);
-
-	const dx = bounds[1][0] - bounds[0][0];
-	const dy = bounds[1][1] - bounds[0][1];
-	const x = (bounds[0][0] + bounds[1][0]) / 2;
-	const y = (bounds[0][1] + bounds[1][1]) / 2;
-
-	// Calculate appropriate zoom level
-	const scale = 0.9 / Math.max(dx / width.value, dy / height.value);
-
-	const translate = [width.value / 2 - scale * x, height.value / 2 - scale * y];
-
-	// Add state to the active location stack
-	const stateName = d.properties.NAME;
-	const state = props.states.find((s) => s.name === stateName);
-	if (state) {
-		activeLocationStack.value.push({
-			type: 'state',
-			name: stateName,
-			data: state,
-		});
-
-		// Update overlay visibility
-		layers.value.stateOverlay.visible = true;
-
-		// Force update the overlay
-		updateOverlays();
-	}
-
-	// Get the stored zoom behavior
-	const zoom = svg.value.__zoom__ || d3.zoom();
-
-	// Animate zoom transition
-	svg.value
-		.transition()
-		.duration(750)
-		.call(
-			zoom.transform,
-			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
-		);
-}
-
-// Handle county click to zoom
-function handleCountyClick(event, d) {
-	event.stopPropagation();
-
-	// Get county bounds
-	const bounds = path.value.bounds(d);
-
-	const dx = bounds[1][0] - bounds[0][0];
-	const dy = bounds[1][1] - bounds[0][1];
-	const x = (bounds[0][0] + bounds[1][0]) / 2;
-	const y = (bounds[0][1] + bounds[1][1]) / 2;
-
-	// Calculate appropriate zoom level - moderate zoom for counties
-	const scale = 0.4 / Math.max(dx / width.value, dy / height.value);
-
-	const translate = [width.value / 2 - scale * x, height.value / 2 - scale * y];
-
-	// Add county to the active location stack
-	let fips;
-	if (d.properties.STATE && d.properties.COUNTY) {
-		fips = d.properties.STATE + d.properties.COUNTY;
-	}
-
-	const county = props.counties.find((c) => c.fips == fips);
-	if (county) {
-		activeLocationStack.value.push({
-			type: 'county',
-			fips: fips,
-			data: county,
-		});
-
-		// Update overlay visibility
-		layers.value.countyOverlay.visible = true;
-		layers.value.stateOverlay.visible = true;
-
-		// Force update the overlay
-		updateOverlays();
-	}
-
-	// Get the stored zoom behavior
-	const zoom = svg.value.__zoom__ || d3.zoom();
-
-	// Animate zoom transition
-	svg.value
-		.transition()
-		.duration(750)
-		.call(
-			zoom.transform,
-			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
-		);
-}
-
-// Reset zoom function
-function resetZoom() {
-	// Clear the active location stack
-	activeLocationStack.value = [];
-
-	// Reset overlay visibility
-	layers.value.stateOverlay.visible = false;
-	layers.value.countyOverlay.visible = false;
-
-	// Remove any existing overlays
-	svg.value.select('.stateOverlay-layer').remove();
-	svg.value.select('.countyOverlay-layer').remove();
-
-	// Get the stored zoom behavior
-	const zoom = svg.value.__zoom__ || d3.zoom();
-
-	// Animate back to default view
-	svg.value.transition().duration(750).call(zoom.transform, d3.zoomIdentity);
-}
-
-// Add zoom controls
-function addZoomControls() {
-	// Add zoom in/out buttons
-	const controls = svg.value
-		.append('g')
-		.attr('class', 'zoom-controls')
-		.attr('transform', `translate(${width.value - 60}, 20)`);
-
-	// Zoom in button
-	controls
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 0)
-		.attr('width', 30)
-		.attr('height', 30)
-		.attr('fill', 'white')
-		.attr('stroke', '#ccc')
-		.attr('rx', 3)
-		.attr('cursor', 'pointer')
-		.on('click', () => {
-			const zoom = svg.value.__zoom__ || d3.zoom();
-			svg.value.transition().call(zoom.scaleBy, 1.5);
-		});
-
-	controls
-		.append('text')
-		.attr('x', 15)
-		.attr('y', 20)
-		.attr('text-anchor', 'middle')
-		.text('+');
-
-	// Zoom out button
-	controls
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 35)
-		.attr('width', 30)
-		.attr('height', 30)
-		.attr('fill', 'white')
-		.attr('stroke', '#ccc')
-		.attr('rx', 3)
-		.attr('cursor', 'pointer')
-		.on('click', () => {
-			const zoom = svg.value.__zoom__ || d3.zoom();
-			svg.value.transition().call(zoom.scaleBy, 0.75);
-		});
-
-	controls
-		.append('text')
-		.attr('x', 15)
-		.attr('y', 55)
-		.attr('text-anchor', 'middle')
-		.text('-');
-
-	// Reset button
-	controls
-		.append('rect')
-		.attr('x', 0)
-		.attr('y', 70)
-		.attr('width', 30)
-		.attr('height', 30)
-		.attr('fill', 'white')
-		.attr('stroke', '#ccc')
-		.attr('rx', 3)
-		.attr('cursor', 'pointer')
-		.on('click', resetZoom);
-
-	controls
-		.append('text')
-		.attr('x', 15)
-		.attr('y', 90)
-		.attr('text-anchor', 'middle')
-		.text('↺');
-}
-
-// Function to update overlays when active location changes
-function updateOverlays() {
-	const container = svg.value.select('.map-container');
-	if (container.empty()) {
-		console.error('Map container not found for overlay update');
-		return;
-	}
-
-	// Check if we have an active location
-	if (activeLocationStack.value.length === 0) {
-		// No active location, remove any overlays
-		svg.value.select('.stateOverlay-layer').remove();
-		svg.value.select('.countyOverlay-layer').remove();
-		return;
-	}
-
-	// Get the most recent active location
-	const activeLocation =
-		activeLocationStack.value[activeLocationStack.value.length - 1];
-
-	// Update overlays based on location type. State is always rendered.
-	if (activeLocation) {
-		if (activeLocation.type === 'state') {
-			// Remove county overlay if it exists
-			svg.value.select('.countyOverlay-layer').remove();
-		}
-
-		// Always render state overlay at minimum
-		renderStateOverlay(container);
-
-		if (activeLocation.type !== 'state') {
-			// Update county overlay
-			renderCountyOverlay(container);
-		}
-	}
-}
-
-function handleTheme() {
-	const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)');
-	const light = FILL_COLORS[0];
-	const mediumLight = FILL_COLORS[2];
-	const mediumDark = FILL_COLORS[FILL_COLORS.length - 3];
-	const dark = FILL_COLORS[FILL_COLORS.length - 1];
-
-	const isDark = prefersDarkTheme.matches;
-	return {
-		prefersDarkTheme,
-		theme: {
-			light,
-			dark,
-			tooltip: {
-				backgroundColor: isDark
-					? 'rgba(40, 40, 40, 0.9)'
-					: 'rgba(0, 0, 0, 0.8)',
-				textColor: light,
-				borderColor: isDark ? '#555' : '#444',
-			},
-			legend: {
-				backgroundColor: isDark
-					? 'rgba(40, 40, 40, 0.8)'
-					: 'rgba(255, 255, 255, 0.7)',
-				textColor: isDark ? light : dark,
-				noDataColor: isDark ? '#555' : 'rgb(220, 220, 220)',
-			},
-			map: {
-				noDataColor: isDark ? '#555' : 'rgb(220, 220, 220)',
-				strokeColor: isDark ? mediumLight : mediumDark,
-				stateBorderColor: isDark ? light : dark, // New color for state boundaries when zoomed in
-				overlayColor: isDark ? 'rgba(0, 0, 0, 0.6)' : 'rgba(0, 0, 0, 0.5)', // Overlay color for non-selected features
-			},
-		},
-	};
 }
 
 // Clean up when component is unmounted
@@ -1397,110 +463,5 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-/* :root {
-rgb(232, 226, 232)
-rgb(212, 204, 213)
-rgb(187, 171, 187)
-rgb(163, 144, 164)
-rgb(140, 118, 140)
-rgb(117, 97, 116)
-rgb(98, 82, 96)
-rgb(80, 66, 79)
-} */
-
-.data-source-map-container {
-	position: relative;
-	width: 100%;
-	height: 100%;
-}
-
-#map-container {
-	width: 100%;
-	height: 100%;
-}
-
-:deep(.counties-layer path) {
-	cursor: pointer;
-}
-
-:deep(.counties-layer path:hover) {
-	/* stroke: rgb(42, 36, 41); */
-	/* stroke-width: 0.5; */
-	filter: brightness(105%);
-}
-
-:deep(.states-layer path) {
-	pointer-events: auto;
-}
-
-:deep(.states-layer path:hover) {
-	/* stroke: #000; */
-	/* stroke-width: 0.5; */
-	filter: brightness(105%);
-}
-
-:deep(.stateBoundaries-layer path),
-:deep(.active-state-border) {
-	pointer-events: none;
-	stroke-width: calc(0.8px * var(--zoom-inversion, 0.5));
-}
-
-:deep(.counties-layer path),
-:deep(.active-county-border) {
-	stroke-width: calc(0.5px * var(--zoom-inversion, 0.5));
-}
-
-:deep(.zoom-controls) {
-	cursor: pointer;
-	user-select: none;
-}
-
-:deep(.zoom-controls text) {
-	pointer-events: none;
-	font-size: 18px;
-	font-weight: bold;
-}
-
-:deep(.localities-layer) {
-	position: relative;
-	z-index: 999999999999999999999999;
-}
-:deep(.localities-layer text) {
-	filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
-}
-
-:deep(.localities-layer text.locality-marker) {
-	font-size: var(--icon-size, 3px);
-}
-
-:deep(.localities-layer text.locality-marker.no-sources) {
-	opacity: 0.3;
-}
-
-:deep(.localities-layer circle) {
-	filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.5));
-}
-
-@media (prefers-color-scheme: dark) {
-	:deep(.counties-layer path:hover) {
-		stroke: rgb(247, 234, 247);
-	}
-
-	:deep(.zoom-controls rect) {
-		fill: #333;
-		stroke: #555;
-	}
-
-	:deep(.zoom-controls text) {
-		fill: #eee;
-	}
-
-	:deep(.localities-layer text) {
-		filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.8));
-	}
-
-	:deep(.localities-layer circle) {
-		filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.8));
-	}
-}
+@import './styles.css';
 </style>

--- a/src/components/d3/DataSourceMapD3.vue
+++ b/src/components/d3/DataSourceMapD3.vue
@@ -41,8 +41,8 @@ import statesGeoJSON from '../../util/geoJSON/states.json';
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 50;
 // Apply a small correction to lat/lng values (to compensate for albers proj) TODO: figure out why this isn't working OOTB
-const LAT_CORRECTION = -0.09; // Negative value moves markers south
-const LNG_CORRECTION = -0.03; // Negative value moves markers west
+const LAT_CORRECTION = -0.085; // Negative value moves markers south
+const LNG_CORRECTION = -0.005; // Positive value moves markers east
 // Define separate breakpoints for counties and states
 const countyColorBreakpoints = [1, 5, 10, 15, 25, 40, 60, 100];
 const stateColorBreakpoints = [1, 10, 25, 50, 100, 200, 500];
@@ -303,6 +303,7 @@ const mapDeps = computed(() => {
 		props,
 		currentTheme: currentTheme.value,
 		localitiesByCounty: localitiesByCounty.value,
+		projection: projection.value,
 		LAT_CORRECTION,
 		LNG_CORRECTION,
 	});

--- a/src/components/d3/DataSourceMapD3.vue
+++ b/src/components/d3/DataSourceMapD3.vue
@@ -91,7 +91,7 @@ const layers = ref({
 	},
 	localities: {
 		visible: true,
-		minZoom: 9,
+		minZoom: 6,
 		maxZoom: Infinity,
 	},
 	states: {
@@ -250,7 +250,7 @@ function initMap() {
 		svg: svg.value,
 		MIN_ZOOM,
 		MAX_ZOOM,
-		handleZoom: (event) => {
+		onZoom: (event) => {
 			// Update overlay visibility before overwriting current zoom
 			activeLocationStack.value = handleOverlaysOnZoom({
 				event,
@@ -264,6 +264,8 @@ function initMap() {
 			// Store current zoom transform
 			zoomTransform.value = event.transform;
 			currentZoom.value = event.transform.k;
+			updateIconSize(currentZoom.value, MAX_ZOOM);
+			updateZoomLevel(currentZoom.value, MAX_ZOOM);
 
 			// Apply transform to all layers
 			const mapContainer = svg.value.select('.map-container');
@@ -280,9 +282,6 @@ function initMap() {
 				svg: svg.value,
 				createLegend: () => createLegend(mapDeps.value),
 			});
-
-			updateIconSize(currentZoom.value, MAX_ZOOM);
-			updateZoomLevel(currentZoom.value, MAX_ZOOM);
 		},
 	});
 
@@ -294,6 +293,7 @@ function initMap() {
 const mapDeps = computed(() => {
 	// Helper function to create overlay deps without circular reference
 	const getOverlayDeps = () => ({
+		container: svg.value.select('.map-container'),
 		svg: svg.value,
 		activeLocationStack: activeLocationStack.value,
 		layers: layers.value,
@@ -310,6 +310,7 @@ const mapDeps = computed(() => {
 
 	return {
 		// Core map properties
+		container: svg.value.select('.map-container'),
 		svg: svg.value,
 		width: width.value,
 		height: height.value,

--- a/src/components/d3/DataSourceMapD3.vue
+++ b/src/components/d3/DataSourceMapD3.vue
@@ -41,7 +41,7 @@ import statesGeoJSON from '../../util/geoJSON/states.json';
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 50;
 // Apply a small correction to lat/lng values (to compensate for albers proj) TODO: figure out why this isn't working OOTB
-const LAT_CORRECTION = -0.1; // Negative value moves markers south
+const LAT_CORRECTION = -0.09; // Negative value moves markers south
 const LNG_CORRECTION = -0.03; // Negative value moves markers west
 // Define separate breakpoints for counties and states
 const countyColorBreakpoints = [1, 5, 10, 15, 25, 40, 60, 100];

--- a/src/components/d3/renderers/counties.js
+++ b/src/components/d3/renderers/counties.js
@@ -1,0 +1,89 @@
+// countiesRenderer.js - Renders the counties layer
+
+/**
+ * Renders the counties layer with choropleth coloring
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderCountiesLayer(container, deps) {
+	const {
+		layers,
+		path,
+		countyDataMap,
+		countyColorScale,
+		currentTheme,
+		tooltip,
+		props,
+		handleCountyClick,
+	} = deps;
+
+	// Always create the layer, but control visibility with CSS
+	const countiesLayer = container
+		.append('g')
+		.attr('class', 'layer counties-layer')
+		.style('display', layers.counties.visible ? 'block' : 'none');
+
+	// Draw counties with choropleth coloring
+	countiesLayer
+		.selectAll('path')
+		.data(layers.counties.data.features)
+		.enter()
+		.append('path')
+		.attr('fill', (d) => {
+			// Use STATE + COUNTY as the FIPS code
+			const props = d.properties;
+			let value;
+
+			if (props.STATE && props.COUNTY) {
+				const fips = props.STATE + props.COUNTY;
+				value = countyDataMap[fips];
+			}
+
+			// Only color counties with at least 1 source
+			return value !== undefined && value > 0
+				? countyColorScale(value)
+				: currentTheme.theme.map.noDataColor; // Theme-appropriate color for counties with no data
+		})
+		.attr('d', path)
+		.attr('stroke', currentTheme.theme.map.strokeColor) // Theme-appropriate stroke for county boundaries
+		.attr('stroke-width', 0.2)
+		.attr('cursor', 'pointer') // Show pointer cursor on counties too
+		.on('click', function (event, d) {
+			console.log('County clicked:', d.properties.NAME || d.properties.COUNTY);
+			event.stopPropagation(); // Stop event bubbling
+			handleCountyClick(event, d);
+		})
+		.on('mouseover', (event, d) => {
+			// Use STATE + COUNTY as the FIPS code
+			let fips;
+			if (d.properties.STATE && d.properties.COUNTY) {
+				fips = d.properties.STATE + d.properties.COUNTY;
+			}
+
+			// Find the county using the FIPS code
+			const county = props.counties.find((c) => c.fips == fips);
+
+			if (county) {
+				tooltip
+					.style('opacity', 0.9)
+					.html(
+						`
+            <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
+              ${county.name}, ${county.state_iso}
+            </div>
+            <div style="margin-bottom:3px;">FIPS: ${county.fips}</div>
+            <div style="font-weight:bold; font-size:13px;">
+              Sources: ${county.source_count}
+            </div>
+          `,
+					)
+					.style('left', event.pageX + 10 + 'px')
+					.style('top', event.pageY - 28 + 'px');
+			}
+		})
+		.on('mouseout', () => {
+			tooltip.style('opacity', 0);
+		});
+
+	console.log('Counties layer rendered, visible:', layers.counties.visible);
+}

--- a/src/components/d3/renderers/counties.js
+++ b/src/components/d3/renderers/counties.js
@@ -15,13 +15,17 @@ export function renderCountiesLayer(container, deps) {
 		tooltip,
 		props,
 		handleCountyClick,
+		STATUSES,
 	} = deps;
 
 	// Always create the layer, but control visibility with CSS
 	const countiesLayer = container
 		.append('g')
 		.attr('class', 'layer counties-layer')
-		.style('display', layers.counties.visible ? 'block' : 'none');
+		.style(
+			'display',
+			layers.counties.status === STATUSES.IDLE ? 'block' : 'none',
+		);
 
 	// Draw counties with choropleth coloring
 	countiesLayer
@@ -84,6 +88,4 @@ export function renderCountiesLayer(container, deps) {
 		.on('mouseout', () => {
 			tooltip.style('opacity', 0);
 		});
-
-	console.log('Counties layer rendered, visible:', layers.counties.visible);
 }

--- a/src/components/d3/renderers/county-overlay.js
+++ b/src/components/d3/renderers/county-overlay.js
@@ -1,0 +1,99 @@
+// countyOverlayRenderer.js - Renders the county overlay layer
+
+/**
+ * Renders the county overlay layer
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderCountyOverlay(container, deps) {
+	const {
+		layers,
+		activeLocationStack,
+		svg,
+		width,
+		height,
+		path,
+		currentTheme
+	} = deps;
+
+	if (
+		!layers.countyOverlay.visible ||
+		activeLocationStack.length === 0
+	)
+		return;
+
+	const activeLocation =
+		activeLocationStack[activeLocationStack.length - 1];
+	if (activeLocation.type === 'state') return;
+
+	console.debug({ activeLocation });
+
+	// Remove any existing overlay first to prevent duplicates
+	svg.select('.countyOverlay-layer').remove();
+
+	const overlayLayer = container
+		.append('g')
+		.attr('class', 'layer countyOverlay-layer')
+		.style('display', layers.countyOverlay.visible ? 'block' : 'none');
+
+	// Create a mask for the active county
+	const maskId = `mask-county-${Date.now()}`; // Use timestamp to ensure uniqueness
+
+	// Add a mask definition
+	const defs = overlayLayer.append('defs');
+	const mask = defs.append('mask').attr('id', maskId);
+
+	// Add a white background to the mask (white = visible area)
+	mask
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 0)
+		.attr('width', width)
+		.attr('height', height)
+		.attr('fill', 'white');
+
+	// Add the county shape to the mask in black (black = invisible area)
+	mask
+		.append('path')
+		.attr(
+			'd',
+			path(
+				layers.countyOverlay.data.features.find((d) => {
+					const fips = d.properties.STATE + d.properties.COUNTY;
+					return (
+						fips === (activeLocation.fips || activeLocation.data.county_fips)
+					);
+				}),
+			),
+		)
+		.attr('fill', 'black');
+
+	// Add a semi-transparent background that covers everything EXCEPT the active county
+	overlayLayer
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 0)
+		.attr('width', width)
+		.attr('height', height)
+		.attr('fill', currentTheme.theme.map.overlayColor)
+		.attr('mask', `url(#${maskId})`)
+		.attr('pointer-events', 'none'); // Allow clicks to pass through
+
+	// Add a stroke around the active county
+	overlayLayer
+		.selectAll('path.active-county-border')
+		.data([
+			layers.countyOverlay.data.features.find((d) => {
+				const fips = d.properties.STATE + d.properties.COUNTY;
+				return fips === activeLocation.fips;
+			}),
+		])
+		.enter()
+		.append('path')
+		.attr('class', 'active-county-border')
+		.attr('fill', 'none')
+		.attr('stroke', currentTheme.theme.map.strokeColor)
+		.attr('stroke-width', 0.5)
+		.attr('d', path)
+		.attr('pointer-events', 'none');
+}

--- a/src/components/d3/renderers/county-overlay.js
+++ b/src/components/d3/renderers/county-overlay.js
@@ -14,14 +14,17 @@ export function renderCountyOverlay(container, deps) {
 		height,
 		path,
 		currentTheme,
+		STATUSES,
 	} = deps;
 
-	if (!layers.countyOverlay.visible || activeLocationStack.length === 0) return;
+	if (
+		layers.countyOverlay.status !== STATUSES.IDLE ||
+		activeLocationStack.length === 0
+	)
+		return;
 
 	const activeLocation = activeLocationStack[activeLocationStack.length - 1];
 	if (activeLocation.type === 'state') return;
-
-	console.debug({ activeLocation });
 
 	// Remove any existing overlay first to prevent duplicates
 	svg.select('.countyOverlay-layer').remove();
@@ -29,7 +32,10 @@ export function renderCountyOverlay(container, deps) {
 	const overlayLayer = container
 		.append('g')
 		.attr('class', 'layer countyOverlay-layer')
-		.style('display', layers.countyOverlay.visible ? 'block' : 'none');
+		.style(
+			'display',
+			layers.countyOverlay.status === STATUSES.IDLE ? 'block' : 'none',
+		);
 
 	// Create a mask for the active county
 	const maskId = `mask-county-${Date.now()}`; // Use timestamp to ensure uniqueness

--- a/src/components/d3/renderers/county-overlay.js
+++ b/src/components/d3/renderers/county-overlay.js
@@ -13,17 +13,12 @@ export function renderCountyOverlay(container, deps) {
 		width,
 		height,
 		path,
-		currentTheme
+		currentTheme,
 	} = deps;
 
-	if (
-		!layers.countyOverlay.visible ||
-		activeLocationStack.length === 0
-	)
-		return;
+	if (!layers.countyOverlay.visible || activeLocationStack.length === 0) return;
 
-	const activeLocation =
-		activeLocationStack[activeLocationStack.length - 1];
+	const activeLocation = activeLocationStack[activeLocationStack.length - 1];
 	if (activeLocation.type === 'state') return;
 
 	console.debug({ activeLocation });

--- a/src/components/d3/renderers/legend.js
+++ b/src/components/d3/renderers/legend.js
@@ -1,0 +1,119 @@
+// legendUtils.js - Utilities for creating and managing the map legend
+
+/**
+ * Creates a simple legend for the map
+ * @param {Object} deps - Master dependencies object
+ */
+export function createLegend(deps) {
+	const {
+		layers,
+		countyColorBreakpoints,
+		stateColorBreakpoints,
+		width,
+		height,
+		svg,
+		currentTheme,
+		FILL_COLORS,
+	} = deps;
+
+	// Determine which layer is visible
+	const visibleLayer = layers.counties.visible ? 'counties' : 'states';
+
+	// Use the appropriate color breakpoints based on visible layer
+	const breakpoints =
+		visibleLayer === 'counties'
+			? countyColorBreakpoints
+			: stateColorBreakpoints;
+
+	// Create legend dimensions
+	const legendWidth = 200;
+	const legendHeight = 30;
+
+	// Position in bottom-right corner with offset to avoid Florida
+	const legendX = width - legendWidth - 40;
+	const legendY = height - legendHeight - 40;
+
+	// Add more space for the "No data" indicator
+	const noDataX = 10;
+	const noDataY = legendHeight + 15;
+
+	// Create legend group
+	const legend = svg
+		.append('g')
+		.attr('class', 'legend')
+		.attr('transform', `translate(${legendX}, ${legendY})`);
+
+	// Add background with theme-appropriate color and border
+	legend
+		.append('rect')
+		.attr('width', legendWidth + 20) // Make wider to include padding
+		.attr('height', legendHeight + 60) // Make taller to include title and "No data" below
+		.attr('x', -10)
+		.attr('y', -25) // Extend upward for title
+		.attr('fill', currentTheme.theme.legend.backgroundColor)
+		.attr('stroke', currentTheme.theme.legend.textColor)
+		.attr('stroke-width', 0.5)
+		.attr('stroke-opacity', 0.3)
+		.attr('rx', 3)
+		.attr('ry', 3);
+
+	// Create color rectangles for the gradient
+	FILL_COLORS.forEach((color, i) => {
+		legend
+			.append('rect')
+			.attr('x', i * (legendWidth / FILL_COLORS.length))
+			.attr('width', legendWidth / FILL_COLORS.length)
+			.attr('height', 20)
+			.attr('fill', color);
+	});
+
+	// Add text labels for min and max
+	legend
+		.append('text')
+		.attr('x', 0)
+		.attr('y', 35)
+		.attr('text-anchor', 'start')
+		.attr('font-size', '10px')
+		.attr('fill', currentTheme.theme.legend.textColor)
+		.text(`${Math.min(...breakpoints)}`);
+
+	legend
+		.append('text')
+		.attr('x', legendWidth)
+		.attr('y', 35)
+		.attr('text-anchor', 'end')
+		.attr('font-size', '10px')
+		.attr('fill', currentTheme.theme.legend.textColor)
+		.text(`${Math.max(...breakpoints)}+`);
+
+	// Add title based on visible layer
+	const title =
+		visibleLayer === 'counties' ? 'County Data Sources' : 'State Data Sources';
+	legend
+		.append('text')
+		.attr('x', legendWidth / 2)
+		.attr('y', -10)
+		.attr('text-anchor', 'middle')
+		.attr('font-size', '12px')
+		.attr('font-weight', 'bold')
+		.attr('fill', currentTheme.theme.legend.textColor)
+		.text(title);
+
+	// Add "No data" indicator below the gradient
+	legend
+		.append('rect')
+		.attr('x', noDataX)
+		.attr('y', noDataY)
+		.attr('width', 10)
+		.attr('height', 10)
+		.attr('fill', currentTheme.theme.legend.noDataColor);
+
+	legend
+		.append('text')
+		.attr('x', noDataX + 15)
+		.attr('y', noDataY + 9) // Align with the square
+		.attr('text-anchor', 'start')
+		.attr('font-size', '9px')
+		.attr('fill', currentTheme.theme.legend.textColor)
+		.text('No data');
+}

--- a/src/components/d3/renderers/legend.js
+++ b/src/components/d3/renderers/legend.js
@@ -20,10 +20,12 @@ export function createLegend(deps) {
 		svg,
 		currentTheme,
 		FILL_COLORS,
+		STATUSES,
 	} = deps;
 
 	// Determine which layer is visible
-	const visibleLayer = layers.counties.visible ? 'counties' : 'states';
+	const visibleLayer =
+		layers.counties.status === STATUSES.IDLE ? 'counties' : 'states';
 
 	// Use the appropriate color breakpoints based on visible layer
 	const breakpoints =

--- a/src/components/d3/renderers/legend.js
+++ b/src/components/d3/renderers/legend.js
@@ -5,6 +5,12 @@
  * @param {Object} deps - Master dependencies object
  */
 export function createLegend(deps) {
+	// Check if all required dependencies are available
+	if (!deps || !deps.svg || !deps.currentTheme || !deps.FILL_COLORS) {
+		console.error('Missing required dependencies for legend:', deps);
+		return;
+	}
+
 	const {
 		layers,
 		countyColorBreakpoints,

--- a/src/components/d3/renderers/localities.js
+++ b/src/components/d3/renderers/localities.js
@@ -11,7 +11,6 @@ let localityGeoJSONCache = {};
  */
 export function renderLocalityMarkers(container, deps) {
 	const {
-		path,
 		projection,
 		tooltip,
 		handleLocalityClick,

--- a/src/components/d3/renderers/localities.js
+++ b/src/components/d3/renderers/localities.js
@@ -1,0 +1,155 @@
+// localityMarkersRenderer.js - Renders the locality markers
+import * as d3 from 'd3';
+
+/**
+ * Renders the locality markers
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderLocalityMarkers(container, deps) {
+	const {
+		layers,
+		props,
+		currentZoom,
+		path,
+		tooltip,
+		handleLocalityClick,
+		LAT_CORRECTION
+	} = deps;
+
+	console.log('Rendering locality markers, count:', props.localities.length);
+	console.log('Current zoom level:', currentZoom);
+
+	// Skip if no localities
+	if (!props.localities || props.localities.length === 0) {
+		console.log('No localities to render');
+		return;
+	}
+
+	// Create a layer for locality markers
+	const localitiesLayer = container
+		.append('g')
+		.attr('class', 'layer localities-layer')
+		.style('display', layers.localities.visible ? 'block' : 'none');
+
+	// Create GeoJSON points for each locality
+	const localityGeoJSON = {
+		type: 'FeatureCollection',
+		features: props.localities
+			.map((locality) => {
+				if (
+					locality.coordinates &&
+					locality.coordinates.lat &&
+					locality.coordinates.lng
+				) {
+					const correctedLat = locality.coordinates.lat + LAT_CORRECTION;
+
+					return {
+						type: 'Feature',
+						properties: locality,
+						geometry: {
+							type: 'Point',
+							// GeoJSON format is [longitude, latitude]
+							coordinates: [locality.coordinates.lng, correctedLat],
+						},
+					};
+				}
+				return null;
+			})
+			.filter(Boolean), // Remove null entries
+	};
+
+	console.log('Created GeoJSON for localities:', localityGeoJSON);
+
+	// Calculate marker size based on zoom level
+	const iconSize = 3;
+
+	// Add markers using path generator directly
+	const markers = localitiesLayer
+		.selectAll('.locality-marker')
+		.data(localityGeoJSON.features)
+		.enter()
+		.append('g')
+		.attr('class', 'locality-marker')
+		.attr('transform', (d) => {
+			// Project the coordinates to screen space
+			console.log('Projecting coordinates:', d.geometry.coordinates);
+
+			// Make sure we have valid coordinates before projecting
+			if (!d.geometry.coordinates || d.geometry.coordinates.length !== 2) {
+				console.error('Invalid coordinates:', d.geometry.coordinates);
+				return null;
+			}
+
+			// Use path.centroid instead of direct projection for more reliable results
+			const centroid = path.centroid(d);
+			if (
+				centroid &&
+				centroid.length === 2 &&
+				!isNaN(centroid[0]) &&
+				!isNaN(centroid[1])
+			) {
+				return `translate(${centroid[0]}, ${centroid[1]})`;
+			}
+
+			return null;
+		});
+
+	// Add Font Awesome icon as text element
+	markers
+		.append('text')
+		.attr(
+			'class',
+			(d) =>
+				`fa locality-marker ${d.properties.source_count ? 'has-sources' : 'no-sources'}`,
+		)
+		.attr('font-family', 'FontAwesome')
+		.attr('text-anchor', 'middle')
+		.attr('dominant-baseline', 'central')
+		.attr('y', -2) // Adjust position slightly
+		.attr('fill', '#ffffff')
+		.attr('cursor', 'pointer')
+		.text('\uf041'); // Font Awesome map marker unicode
+
+	// Add click and hover handlers
+	markers
+		.on('click', (event, d) => {
+			event.stopPropagation();
+			handleLocalityClick(event, d.properties);
+		})
+		.on('mouseover', function (event, d) {
+			const locality = d.properties;
+			// Show tooltip with locality information
+			tooltip
+				.style('opacity', 0.9)
+				.html(
+					`
+          <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
+            ${locality.name}
+          </div>
+          <div style="margin-bottom:3px;">
+            ${locality.county_name ? locality.county_name + ' County' : ''}
+          </div>
+          <div style="font-weight:bold; font-size:13px;">
+            Sources: ${locality.source_count}
+          </div>
+        `,
+				)
+				.style('left', event.pageX + 10 + 'px')
+				.style('top', event.pageY - 28 + 'px');
+
+			// Highlight the marker
+			d3.select(this)
+				.select('text')
+				.attr('font-size', `${iconSize * 1.25}px`);
+		})
+		.on('mouseout', function () {
+			// Hide tooltip
+			tooltip.style('opacity', 0);
+
+			// Reset marker style
+			d3.select(this).select('text').attr('font-size', `${iconSize}px`);
+		});
+
+	console.log('Localities layer rendered with', markers.size(), 'markers');
+}

--- a/src/components/d3/renderers/localities.js
+++ b/src/components/d3/renderers/localities.js
@@ -38,6 +38,9 @@ export function renderLocalityMarkers(container, deps) {
 			? activeLocation.fips
 			: activeLocation.data.county_fips;
 
+	// Remove any existing localities layer first
+	container.select('.localities-layer').remove();
+
 	// Create a layer for locality markers
 	const localitiesLayer = container
 		.append('g')

--- a/src/components/d3/renderers/localities.js
+++ b/src/components/d3/renderers/localities.js
@@ -12,6 +12,7 @@ let localityGeoJSONCache = {};
 export function renderLocalityMarkers(container, deps) {
 	const {
 		path,
+		projection,
 		tooltip,
 		handleLocalityClick,
 		LAT_CORRECTION,
@@ -92,15 +93,11 @@ export function renderLocalityMarkers(container, deps) {
 				return null;
 			}
 
-			// Use path.centroid instead of direct projection for more reliable results
-			const centroid = path.centroid(d);
-			if (
-				centroid &&
-				centroid.length === 2 &&
-				!isNaN(centroid[0]) &&
-				!isNaN(centroid[1])
-			) {
-				return `translate(${centroid[0]}, ${centroid[1]})`;
+			// Use projection directly to convert coordinates to screen position
+			const coords = d.geometry.coordinates;
+			const pos = projection(coords);
+			if (pos && !isNaN(pos[0]) && !isNaN(pos[1])) {
+				return `translate(${pos[0]}, ${pos[1]})`;
 			}
 
 			return null;

--- a/src/components/d3/renderers/state-boundaries.js
+++ b/src/components/d3/renderers/state-boundaries.js
@@ -1,0 +1,35 @@
+// stateBoundariesRenderer.js - Renders the state boundaries layer
+
+/**
+ * Renders the state boundaries layer (outlines only)
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderStateBoundariesLayer(container, deps) {
+	const {
+		layers,
+		path,
+		currentTheme
+	} = deps;
+
+	// Always create the layer, but control visibility with CSS
+	const boundariesLayer = container
+		.append('g')
+		.attr('class', 'layer stateBoundaries-layer')
+		.style('display', layers.stateBoundaries.visible ? 'block' : 'none');
+
+	// Draw state boundaries with no fill, just strokes
+	boundariesLayer
+		.selectAll('path')
+		.data(layers.stateBoundaries.data.features)
+		.enter()
+		.append('path')
+		.attr('fill', 'none')
+		.attr('stroke', currentTheme.theme.map.stateBorderColor)
+		.attr('d', path);
+
+	console.log(
+		'State boundaries layer rendered, visible:',
+		layers.stateBoundaries.visible,
+	);
+}

--- a/src/components/d3/renderers/state-boundaries.js
+++ b/src/components/d3/renderers/state-boundaries.js
@@ -6,13 +6,16 @@
  * @param {Object} deps - Master dependencies object
  */
 export function renderStateBoundariesLayer(container, deps) {
-	const { layers, path, currentTheme } = deps;
+	const { layers, path, currentTheme, STATUSES } = deps;
 
 	// Always create the layer, but control visibility with CSS
 	const boundariesLayer = container
 		.append('g')
 		.attr('class', 'layer stateBoundaries-layer')
-		.style('display', layers.stateBoundaries.visible ? 'block' : 'none');
+		.style(
+			'display',
+			layers.stateBoundaries.status === STATUSES.IDLE ? 'block' : 'none',
+		);
 
 	// Draw state boundaries with no fill, just strokes
 	boundariesLayer
@@ -23,9 +26,4 @@ export function renderStateBoundariesLayer(container, deps) {
 		.attr('fill', 'none')
 		.attr('stroke', currentTheme.theme.map.stateBorderColor)
 		.attr('d', path);
-
-	console.log(
-		'State boundaries layer rendered, visible:',
-		layers.stateBoundaries.visible,
-	);
 }

--- a/src/components/d3/renderers/state-boundaries.js
+++ b/src/components/d3/renderers/state-boundaries.js
@@ -6,11 +6,7 @@
  * @param {Object} deps - Master dependencies object
  */
 export function renderStateBoundariesLayer(container, deps) {
-	const {
-		layers,
-		path,
-		currentTheme
-	} = deps;
+	const { layers, path, currentTheme } = deps;
 
 	// Always create the layer, but control visibility with CSS
 	const boundariesLayer = container

--- a/src/components/d3/renderers/state-overlay.js
+++ b/src/components/d3/renderers/state-overlay.js
@@ -15,9 +15,14 @@ export function renderStateOverlay(container, deps) {
 		height,
 		path,
 		currentTheme,
+		STATUSES,
 	} = deps;
 
-	if (!layers?.stateOverlay.visible || activeLocationStack.length === 0) return;
+	if (
+		layers?.stateOverlay.status !== STATUSES.IDLE ||
+		activeLocationStack.length === 0
+	)
+		return;
 
 	const activeState = props.states.find(
 		(state) =>
@@ -38,7 +43,10 @@ export function renderStateOverlay(container, deps) {
 	const overlayLayer = container
 		.append('g')
 		.attr('class', 'layer stateOverlay-layer')
-		.style('display', layers.stateOverlay.visible ? 'block' : 'none');
+		.style(
+			'display',
+			layers.stateOverlay.status === STATUSES.IDLE ? 'block' : 'none',
+		);
 
 	// Create a mask for the active state
 	const maskId = `mask-state-${Date.now()}`; // Use timestamp to ensure uniqueness
@@ -52,8 +60,8 @@ export function renderStateOverlay(container, deps) {
 		.append('rect')
 		.attr('x', 0)
 		.attr('y', 0)
-		.attr('width', width)
-		.attr('height', height)
+		.attr('width', '100%')
+		.attr('height', '100%')
 		.attr('fill', 'white');
 
 	// Add the state shape to the mask in black (black = invisible area)

--- a/src/components/d3/renderers/state-overlay.js
+++ b/src/components/d3/renderers/state-overlay.js
@@ -1,0 +1,100 @@
+// stateOverlayRenderer.js - Renders the state overlay layer
+
+/**
+ * Renders the state overlay layer
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderStateOverlay(container, deps) {
+	const {
+		layers,
+		activeLocationStack,
+		props,
+		svg,
+		width,
+		height,
+		path,
+		currentTheme,
+	} = deps;
+
+	if (!layers?.stateOverlay.visible || activeLocationStack.length === 0) return;
+
+	const activeState = props.states.find(
+		(state) =>
+			state.state_iso ===
+			activeLocationStack[activeLocationStack.length - 1].data.state_iso,
+	);
+
+	console.debug({
+		activeState,
+		activeLocationStack: activeLocationStack,
+	});
+
+	if (!activeState) return;
+
+	// Remove any existing overlay first to prevent duplicates
+	svg.select('.stateOverlay-layer').remove();
+
+	const overlayLayer = container
+		.append('g')
+		.attr('class', 'layer stateOverlay-layer')
+		.style('display', layers.stateOverlay.visible ? 'block' : 'none');
+
+	// Create a mask for the active state
+	const maskId = `mask-state-${Date.now()}`; // Use timestamp to ensure uniqueness
+
+	// Add a mask definition
+	const defs = overlayLayer.append('defs');
+	const mask = defs.append('mask').attr('id', maskId);
+
+	// Add a white background to the mask (white = visible area)
+	mask
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 0)
+		.attr('width', width)
+		.attr('height', height)
+		.attr('fill', 'white');
+
+	// Add the state shape to the mask in black (black = invisible area)
+	mask
+		.append('path')
+		.attr(
+			'd',
+			path(
+				layers.stateOverlay.data.features.find(
+					(d) => d.properties.NAME === activeState.name,
+				),
+			),
+		)
+		.attr('fill', 'black');
+
+	// Add a semi-transparent background that covers everything EXCEPT the active state
+	overlayLayer
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 0)
+		.attr('width', width)
+		.attr('height', height)
+		.attr('fill', currentTheme.theme.map.overlayColor)
+		.attr('mask', `url(#${maskId})`)
+		.attr('pointer-events', 'none'); // Allow clicks to pass through
+
+	// Add a stroke around the active state
+	overlayLayer
+		.selectAll('path.active-state-border')
+		.data([
+			layers.stateOverlay.data.features.find(
+				(d) => d.properties.NAME === activeState.name,
+			),
+		])
+		.enter()
+		.append('path')
+		.attr('class', 'active-state-border')
+		.attr('fill', 'none') // No fill, just stroke
+		.attr('stroke', currentTheme.theme.map.stateBorderColor)
+		.attr('d', path)
+		.attr('pointer-events', 'none'); // Allow clicks to pass through
+
+	console.log('State overlay layer rendered, active state:', activeState.name);
+}

--- a/src/components/d3/renderers/states.js
+++ b/src/components/d3/renderers/states.js
@@ -15,13 +15,17 @@ export function renderStatesLayer(container, deps) {
 		tooltip,
 		handleStateClick,
 		props,
+		STATUSES,
 	} = deps;
 
 	// Always create the layer, but control visibility with CSS
 	const statesLayer = container
 		.append('g')
 		.attr('class', 'layer states-layer')
-		.style('display', layers.states.visible ? 'block' : 'none');
+		.style(
+			'display',
+			layers.states.status === STATUSES.IDLE ? 'block' : 'none',
+		);
 
 	// Draw states with choropleth coloring
 	statesLayer

--- a/src/components/d3/renderers/states.js
+++ b/src/components/d3/renderers/states.js
@@ -1,0 +1,75 @@
+// statesRenderer.js - Renders the states layer
+
+/**
+ * Renders the states layer with choropleth coloring
+ * @param {Object} container - D3 selection for the container
+ * @param {Object} deps - Master dependencies object
+ */
+export function renderStatesLayer(container, deps) {
+	const {
+		layers,
+		path,
+		stateDataMap,
+		stateColorScale,
+		currentTheme,
+		tooltip,
+		handleStateClick,
+		props
+	} = deps;
+
+	// Always create the layer, but control visibility with CSS
+	const statesLayer = container
+		.append('g')
+		.attr('class', 'layer states-layer')
+		.style('display', layers.states.visible ? 'block' : 'none');
+
+	// Draw states with choropleth coloring
+	statesLayer
+		.selectAll('path')
+		.data(layers.states.data.features)
+		.enter()
+		.append('path')
+		.attr('fill', (d) => {
+			// Use state name to look up data
+			const stateName = d.properties.NAME;
+			const value = stateDataMap[stateName];
+
+			// Only color states with at least 1 source
+			return value !== undefined && value > 0
+				? stateColorScale(value)
+				: currentTheme.theme.map.noDataColor; // Theme-appropriate color for states with no data
+		})
+		.attr('stroke', currentTheme.theme.map.stateBorderColor)
+		.attr('stroke-width', 0.5)
+		.attr('d', path)
+		.attr('cursor', 'pointer')
+		.on('click', function (event, d) {
+			event.stopPropagation(); // Stop event bubbling
+			handleStateClick(event, d);
+		})
+		.on('mouseover', (event, d) => {
+			// Find the state using the name
+			const stateName = d.properties.NAME;
+			const state = props.states.find((s) => s.name === stateName);
+
+			if (state) {
+				tooltip
+					.style('opacity', 0.9)
+					.html(
+						`
+            <div style="font-weight:bold; font-size:14px; margin-bottom:5px;">
+              ${state.name}
+            </div>
+            <div style="font-weight:bold; font-size:13px;">
+              Sources: ${state.source_count}
+            </div>
+          `,
+					)
+					.style('left', event.pageX + 10 + 'px')
+					.style('top', event.pageY - 28 + 'px');
+			}
+		})
+		.on('mouseout', () => {
+			tooltip.style('opacity', 0);
+		});
+}

--- a/src/components/d3/renderers/states.js
+++ b/src/components/d3/renderers/states.js
@@ -14,7 +14,7 @@ export function renderStatesLayer(container, deps) {
 		currentTheme,
 		tooltip,
 		handleStateClick,
-		props
+		props,
 	} = deps;
 
 	// Always create the layer, but control visibility with CSS

--- a/src/components/d3/renderers/tooltip.js
+++ b/src/components/d3/renderers/tooltip.js
@@ -1,0 +1,23 @@
+import * as d3 from 'd3';
+
+export function createTooltip(tooltip, currentTheme) {
+	// Create tooltip
+	tooltip.value = d3
+		.select('body')
+		.append('div')
+		.attr('class', 'tooltip')
+		.style('opacity', 0)
+		.style('position', 'absolute')
+		.style('background-color', currentTheme.value.theme.tooltip.backgroundColor)
+		.style('color', currentTheme.value.theme.tooltip.textColor)
+		.style(
+			'border',
+			`1px solid ${currentTheme.value.theme.tooltip.borderColor}`,
+		)
+		.style('padding', '10px')
+		.style('border-radius', '3px')
+		.style('pointer-events', 'none')
+		.style('z-index', 1000)
+		.style('font-size', '12px')
+		.style('box-shadow', '0 2px 5px rgba(0,0,0,0.2)');
+}

--- a/src/components/d3/styles.css
+++ b/src/components/d3/styles.css
@@ -1,0 +1,95 @@
+.data-source-map-container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}
+
+#map-container {
+	width: 100%;
+	height: 100%;
+}
+
+:deep(.counties-layer path) {
+	cursor: pointer;
+}
+
+:deep(.counties-layer path:hover) {
+	/* stroke: rgb(42, 36, 41); */
+	/* stroke-width: 0.5; */
+	filter: brightness(105%);
+}
+
+:deep(.states-layer path) {
+	pointer-events: auto;
+}
+
+:deep(.states-layer path:hover) {
+	/* stroke: #000; */
+	/* stroke-width: 0.5; */
+	filter: brightness(105%);
+}
+
+:deep(.stateBoundaries-layer path),
+:deep(.active-state-border) {
+	pointer-events: none;
+	stroke-width: calc(0.8px * var(--zoom-inversion, 0.5));
+}
+
+:deep(.counties-layer path),
+:deep(.active-county-border) {
+	stroke-width: calc(0.5px * var(--zoom-inversion, 0.5));
+}
+
+:deep(.zoom-controls) {
+	cursor: pointer;
+	user-select: none;
+}
+
+:deep(.zoom-controls text) {
+	pointer-events: none;
+	font-size: 18px;
+	font-weight: bold;
+}
+
+:deep(.localities-layer) {
+	position: relative;
+	z-index: 999999999999999999999999;
+}
+:deep(.localities-layer text) {
+	filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
+}
+
+:deep(.localities-layer text.locality-marker) {
+	font-size: var(--icon-size, 3px);
+}
+
+:deep(.localities-layer text.locality-marker.no-sources) {
+	opacity: 0.3;
+}
+
+:deep(.localities-layer circle) {
+	filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.5));
+}
+
+@media (prefers-color-scheme: dark) {
+	:deep(.counties-layer path:hover) {
+		stroke: rgb(247, 234, 247);
+	}
+
+	:deep(.zoom-controls rect) {
+		fill: #333;
+		stroke: #555;
+	}
+
+	:deep(.zoom-controls text) {
+		fill: #eee;
+	}
+
+	:deep(.localities-layer text) {
+		filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.8));
+	}
+
+	:deep(.localities-layer circle) {
+		filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.8));
+	}
+}

--- a/src/components/d3/styles.css
+++ b/src/components/d3/styles.css
@@ -1,7 +1,9 @@
 .data-source-map-container {
 	position: relative;
 	width: 100%;
-	height: 100%;
+	height: auto;
+	max-width: 1245px;
+	margin: 0 auto;
 }
 
 #map-container {

--- a/src/components/d3/styles.css
+++ b/src/components/d3/styles.css
@@ -32,12 +32,12 @@
 :deep(.stateBoundaries-layer path),
 :deep(.active-state-border) {
 	pointer-events: none;
-	stroke-width: calc(0.8px * var(--zoom-inversion, 0.5));
+	stroke-width: calc(0.35px * var(--zoom-inversion, 0.5));
 }
 
 :deep(.counties-layer path),
 :deep(.active-county-border) {
-	stroke-width: calc(0.5px * var(--zoom-inversion, 0.5));
+	stroke-width: calc(0.3px * var(--zoom-inversion, 0.5));
 }
 
 :deep(.zoom-controls) {

--- a/src/components/d3/styles.css
+++ b/src/components/d3/styles.css
@@ -60,7 +60,7 @@
 }
 
 :deep(.localities-layer text.locality-marker) {
-	font-size: var(--icon-size, 3px);
+	font-size: var(--icon-size);
 }
 
 :deep(.localities-layer text.locality-marker.no-sources) {

--- a/src/components/d3/utils/createOverlayDeps.js
+++ b/src/components/d3/utils/createOverlayDeps.js
@@ -3,23 +3,23 @@
  * This avoids circular references in the mapDeps object
  */
 export function createOverlayDeps({
-  svg,
-  activeLocationStack,
-  layers,
-  path,
-  width,
-  height,
-  props,
-  currentTheme
+	svg,
+	activeLocationStack,
+	layers,
+	path,
+	width,
+	height,
+	props,
+	currentTheme,
 }) {
-  return {
-    svg,
-    activeLocationStack,
-    layers,
-    path,
-    width,
-    height,
-    props,
-    currentTheme
-  };
+	return {
+		svg,
+		activeLocationStack,
+		layers,
+		path,
+		width,
+		height,
+		props,
+		currentTheme,
+	};
 }

--- a/src/components/d3/utils/createOverlayDeps.js
+++ b/src/components/d3/utils/createOverlayDeps.js
@@ -1,0 +1,25 @@
+/**
+ * Helper function to create a clean dependency object for overlay updates
+ * This avoids circular references in the mapDeps object
+ */
+export function createOverlayDeps({
+  svg,
+  activeLocationStack,
+  layers,
+  path,
+  width,
+  height,
+  props,
+  currentTheme
+}) {
+  return {
+    svg,
+    activeLocationStack,
+    layers,
+    path,
+    width,
+    height,
+    props,
+    currentTheme
+  };
+}

--- a/src/components/d3/utils/interaction.js
+++ b/src/components/d3/utils/interaction.js
@@ -17,6 +17,7 @@ export function handleStateClick({
 	layers,
 	svg,
 	updateDynamicLayers,
+	STATUSES,
 }) {
 	event.stopPropagation();
 
@@ -48,7 +49,7 @@ export function handleStateClick({
 		activeLocationStack.splice(0, activeLocationStack.length, ...newStack);
 
 		// Update overlay visibility
-		layers.stateOverlay.visible = true;
+		layers.stateOverlay.status = STATUSES.IDLE;
 
 		// Force update the overlay
 		updateDynamicLayers();
@@ -84,6 +85,7 @@ export function handleCountyClick({
 	layers,
 	svg,
 	updateDynamicLayers,
+	STATUSES,
 }) {
 	event.stopPropagation();
 
@@ -120,8 +122,8 @@ export function handleCountyClick({
 		activeLocationStack.splice(0, activeLocationStack.length, ...newStack);
 
 		// Update overlay visibility
-		layers.countyOverlay.visible = true;
-		layers.stateOverlay.visible = true;
+		layers.countyOverlay.status = STATUSES.IDLE;
+		layers.stateOverlay.status = STATUSES.IDLE;
 
 		// Force update the overlay
 		updateDynamicLayers();
@@ -174,13 +176,13 @@ export function handleLocalityClick({
  * Resets zoom to default view
  * @param {Object} params - Parameters needed for resetting zoom
  */
-export function resetZoom({ activeLocationStack, layers, svg }) {
+export function resetZoom({ activeLocationStack, layers, svg, STATUSES }) {
 	// Clear the active location stack
 	activeLocationStack.splice(0, activeLocationStack.length);
 
 	// Reset overlay visibility
-	layers.stateOverlay.visible = false;
-	layers.countyOverlay.visible = false;
+	layers.stateOverlay.status = STATUSES.HIDDEN;
+	layers.countyOverlay.status = STATUSES.HIDDEN;
 
 	// Remove any existing overlays
 	svg.select('.stateOverlay-layer').remove();

--- a/src/components/d3/utils/interaction.js
+++ b/src/components/d3/utils/interaction.js
@@ -1,0 +1,208 @@
+// interactionUtils.js - Utilities for handling user interactions
+
+import * as d3 from 'd3';
+
+/**
+ * Handles state click to zoom
+ * @param {Object} params - Parameters needed for handling state click
+ */
+export function handleStateClick({
+	event,
+	d,
+	path,
+	width,
+	height,
+	props,
+	activeLocationStack,
+	layers,
+	svg,
+	updateOverlays,
+}) {
+	event.stopPropagation();
+
+	const bounds = path.bounds(d);
+
+	const dx = bounds[1][0] - bounds[0][0];
+	const dy = bounds[1][1] - bounds[0][1];
+	const x = (bounds[0][0] + bounds[1][0]) / 2;
+	const y = (bounds[0][1] + bounds[1][1]) / 2;
+
+	// Calculate appropriate zoom level
+	const scale = 0.9 / Math.max(dx / width, dy / height);
+
+	const translate = [width / 2 - scale * x, height / 2 - scale * y];
+
+	// Add state to the active location stack
+	const stateName = d.properties.NAME;
+	const state = props.states.find((s) => s.name === stateName);
+	if (state) {
+		activeLocationStack.push({
+			type: 'state',
+			name: stateName,
+			data: state,
+		});
+
+		// Update overlay visibility
+		layers.stateOverlay.visible = true;
+
+		// Force update the overlay
+		updateOverlays();
+	}
+
+	// Get the stored zoom behavior
+	const zoom = svg.__zoom__ || d3.zoom();
+
+	// Animate zoom transition
+	svg
+		.transition()
+		.duration(750)
+		.call(
+			zoom.transform,
+			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
+		);
+
+	return activeLocationStack;
+}
+
+/**
+ * Handles county click to zoom
+ * @param {Object} params - Parameters needed for handling county click
+ */
+export function handleCountyClick({
+	event,
+	d,
+	path,
+	width,
+	height,
+	props,
+	activeLocationStack,
+	layers,
+	svg,
+	updateOverlays,
+}) {
+	event.stopPropagation();
+
+	// Get county bounds
+	const bounds = path.bounds(d);
+
+	const dx = bounds[1][0] - bounds[0][0];
+	const dy = bounds[1][1] - bounds[0][1];
+	const x = (bounds[0][0] + bounds[1][0]) / 2;
+	const y = (bounds[0][1] + bounds[1][1]) / 2;
+
+	// Calculate appropriate zoom level - moderate zoom for counties
+	const scale = 0.4 / Math.max(dx / width, dy / height);
+
+	const translate = [width / 2 - scale * x, height / 2 - scale * y];
+
+	// Add county to the active location stack
+	let fips;
+	if (d.properties.STATE && d.properties.COUNTY) {
+		fips = d.properties.STATE + d.properties.COUNTY;
+	}
+
+	const county = props.counties.find((c) => c.fips == fips);
+	if (county) {
+		activeLocationStack.push({
+			type: 'county',
+			fips: fips,
+			data: county,
+		});
+
+		// Update overlay visibility
+		layers.countyOverlay.visible = true;
+		layers.stateOverlay.visible = true;
+
+		// Force update the overlay
+		updateOverlays();
+	}
+
+	// Get the stored zoom behavior
+	const zoom = svg.__zoom__ || d3.zoom();
+
+	// Animate zoom transition
+	svg
+		.transition()
+		.duration(750)
+		.call(
+			zoom.transform,
+			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
+		);
+
+	return activeLocationStack;
+}
+
+/**
+ * Handles locality marker click
+ * @param {Object} params - Parameters needed for handling locality click
+ */
+export function handleLocalityClick({
+	// event,
+	locality,
+	projection,
+	width,
+	height,
+	activeLocationStack,
+	updateOverlays,
+	svg,
+	LAT_CORRECTION,
+}) {
+	console.log('Locality clicked:', locality.name);
+	const correctedLat = locality.coordinates.lat + LAT_CORRECTION;
+
+	// Convert lat/lng to pixel coordinates
+	const [x, y] = projection([locality.coordinates.lng, correctedLat]);
+
+	const scale = 30;
+
+	const translate = [width / 2 - scale * x, height / 2 - scale * y];
+
+	// Add locality to the active location stack
+	activeLocationStack.push({
+		type: 'locality',
+		name: locality.name,
+		data: locality,
+		fips: locality.county_fips,
+	});
+
+	updateOverlays();
+
+	// Get the stored zoom behavior
+	const zoom = svg.__zoom__ || d3.zoom();
+
+	// Animate zoom transition
+	svg
+		.transition()
+		.duration(750)
+		.call(
+			zoom.transform,
+			d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale),
+		);
+
+	return activeLocationStack;
+}
+
+/**
+ * Resets zoom to default view
+ * @param {Object} params - Parameters needed for resetting zoom
+ */
+export function resetZoom({ activeLocationStack, layers, svg }) {
+	// Clear the active location stack
+	activeLocationStack = [];
+
+	// Reset overlay visibility
+	layers.stateOverlay.visible = false;
+	layers.countyOverlay.visible = false;
+
+	// Remove any existing overlays
+	svg.select('.stateOverlay-layer').remove();
+	svg.select('.countyOverlay-layer').remove();
+
+	// Get the stored zoom behavior
+	const zoom = svg.__zoom__ || d3.zoom();
+
+	// Animate back to default view
+	svg.transition().duration(750).call(zoom.transform, d3.zoomIdentity);
+
+	return activeLocationStack;
+}

--- a/src/components/d3/utils/interaction.js
+++ b/src/components/d3/utils/interaction.js
@@ -96,7 +96,7 @@ export function handleCountyClick({
 	const y = (bounds[0][1] + bounds[1][1]) / 2;
 
 	// Calculate appropriate zoom level - moderate zoom for counties
-	const scale = 0.4 / Math.max(dx / width, dy / height);
+	const scale = 0.5 / Math.max(dx / width, dy / height);
 
 	const translate = [width / 2 - scale * x, height / 2 - scale * y];
 

--- a/src/components/d3/utils/overlay.js
+++ b/src/components/d3/utils/overlay.js
@@ -44,9 +44,12 @@ export function updateDynamicLayers({
 		if (activeLocation.type !== 'state') {
 			// Update county overlay
 			renderCountyOverlay(container, deps);
-			
+
 			// Render locality markers for county or locality selections
-			if (activeLocation.type === 'county' || activeLocation.type === 'locality') {
+			if (
+				activeLocation.type === 'county' ||
+				activeLocation.type === 'locality'
+			) {
 				renderLocalityMarkers(container, deps);
 			}
 		}

--- a/src/components/d3/utils/overlay.js
+++ b/src/components/d3/utils/overlay.js
@@ -1,19 +1,20 @@
-// overlayUtils.js - Utilities for handling map overlays
+// overlayUtils.js - Utilities for handling dynamic map layers
 
 /**
- * Updates overlays when active location changes
- * @param {Object} params - Parameters needed for updating overlays
+ * Updates dynamic layers when active location changes
+ * @param {Object} params - Parameters needed for updating dynamic layers
  */
-export function updateOverlays({
+export function updateDynamicLayers({
 	renderStateOverlay,
 	renderCountyOverlay,
+	renderLocalityMarkers,
 	deps,
 }) {
 	const { svg, activeLocationStack } = deps;
 
 	const container = svg.select('.map-container');
 	if (container.empty()) {
-		console.error('Map container not found for overlay update');
+		console.error('Map container not found for dynamic layer update');
 		return;
 	}
 
@@ -22,17 +23,19 @@ export function updateOverlays({
 		// No active location, remove any overlays
 		svg.select('.stateOverlay-layer').remove();
 		svg.select('.countyOverlay-layer').remove();
+		svg.select('.localities-layer').remove();
 		return;
 	}
 
 	// Get the most recent active location
 	const activeLocation = activeLocationStack[activeLocationStack.length - 1];
 
-	// Update overlays based on location type. State is always rendered.
+	// Update layers based on location type
 	if (activeLocation) {
 		if (activeLocation.type === 'state') {
-			// Remove county overlay if it exists
+			// Remove county overlay and localities if they exist
 			svg.select('.countyOverlay-layer').remove();
+			svg.select('.localities-layer').remove();
 		}
 
 		// Always render state overlay at minimum
@@ -41,6 +44,11 @@ export function updateOverlays({
 		if (activeLocation.type !== 'state') {
 			// Update county overlay
 			renderCountyOverlay(container, deps);
+			
+			// Render locality markers for county or locality selections
+			if (activeLocation.type === 'county' || activeLocation.type === 'locality') {
+				renderLocalityMarkers(container, deps);
+			}
 		}
 	}
 }

--- a/src/components/d3/utils/overlay.js
+++ b/src/components/d3/utils/overlay.js
@@ -1,0 +1,46 @@
+// overlayUtils.js - Utilities for handling map overlays
+
+/**
+ * Updates overlays when active location changes
+ * @param {Object} params - Parameters needed for updating overlays
+ */
+export function updateOverlays({
+	renderStateOverlay,
+	renderCountyOverlay,
+	deps,
+}) {
+	const { svg, activeLocationStack } = deps;
+
+	const container = svg.select('.map-container');
+	if (container.empty()) {
+		console.error('Map container not found for overlay update');
+		return;
+	}
+
+	// Check if we have an active location
+	if (activeLocationStack.length === 0) {
+		// No active location, remove any overlays
+		svg.select('.stateOverlay-layer').remove();
+		svg.select('.countyOverlay-layer').remove();
+		return;
+	}
+
+	// Get the most recent active location
+	const activeLocation = activeLocationStack[activeLocationStack.length - 1];
+
+	// Update overlays based on location type. State is always rendered.
+	if (activeLocation) {
+		if (activeLocation.type === 'state') {
+			// Remove county overlay if it exists
+			svg.select('.countyOverlay-layer').remove();
+		}
+
+		// Always render state overlay at minimum
+		renderStateOverlay(container, deps);
+
+		if (activeLocation.type !== 'state') {
+			// Update county overlay
+			renderCountyOverlay(container, deps);
+		}
+	}
+}

--- a/src/components/d3/utils/overlayHelper.js
+++ b/src/components/d3/utils/overlayHelper.js
@@ -1,0 +1,17 @@
+/**
+ * Helper function to create a clean dependency object for overlay updates
+ * This avoids circular references in the mapDeps object
+ */
+export function createOverlayDeps(deps) {
+  // Extract only the properties needed for overlay operations
+  return {
+    svg: deps.svg,
+    activeLocationStack: deps.activeLocationStack,
+    layers: deps.layers,
+    path: deps.path,
+    width: deps.width,
+    height: deps.height,
+    props: deps.props,
+    currentTheme: deps.currentTheme
+  };
+}

--- a/src/components/d3/utils/overlayHelper.js
+++ b/src/components/d3/utils/overlayHelper.js
@@ -3,15 +3,15 @@
  * This avoids circular references in the mapDeps object
  */
 export function createOverlayDeps(deps) {
-  // Extract only the properties needed for overlay operations
-  return {
-    svg: deps.svg,
-    activeLocationStack: deps.activeLocationStack,
-    layers: deps.layers,
-    path: deps.path,
-    width: deps.width,
-    height: deps.height,
-    props: deps.props,
-    currentTheme: deps.currentTheme
-  };
+	// Extract only the properties needed for overlay operations
+	return {
+		svg: deps.svg,
+		activeLocationStack: deps.activeLocationStack,
+		layers: deps.layers,
+		path: deps.path,
+		width: deps.width,
+		height: deps.height,
+		props: deps.props,
+		currentTheme: deps.currentTheme,
+	};
 }

--- a/src/components/d3/utils/theme.js
+++ b/src/components/d3/utils/theme.js
@@ -1,0 +1,55 @@
+// themeUtils.js - Utilities for handling theme
+export const FILL_COLORS = [
+	// 'rgb(247, 247, 248)',
+	// 'rgb(242, 240, 243)',
+	'rgb(232, 226, 232)',
+	'rgb(212, 204, 213)',
+	'rgb(187, 171, 187)',
+	'rgb(163, 144, 164)',
+	'rgb(140, 118, 140)',
+	'rgb(117, 97, 116)',
+	'rgb(98, 82, 96)',
+	'rgb(80, 66, 79)',
+];
+
+/**
+ * Handles theme detection and returns theme configuration
+ * @param {Array} COLORS - Array of fill colors for the map
+ * @returns {Object} Theme configuration
+ */
+export function handleTheme(COLORS = FILL_COLORS) {
+	const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)');
+	const light = COLORS[0];
+	const mediumLight = COLORS[2];
+	const mediumDark = COLORS[COLORS.length - 3];
+	const dark = COLORS[COLORS.length - 1];
+
+	const isDark = prefersDarkTheme.matches;
+	return {
+		prefersDarkTheme,
+		theme: {
+			light,
+			dark,
+			tooltip: {
+				backgroundColor: isDark
+					? 'rgba(40, 40, 40, 0.9)'
+					: 'rgba(0, 0, 0, 0.8)',
+				textColor: light,
+				borderColor: isDark ? '#555' : '#444',
+			},
+			legend: {
+				backgroundColor: isDark
+					? 'rgba(40, 40, 40, 0.8)'
+					: 'rgba(255, 255, 255, 0.7)',
+				textColor: isDark ? light : dark,
+				noDataColor: isDark ? '#555' : 'rgb(220, 220, 220)',
+			},
+			map: {
+				noDataColor: isDark ? '#555' : 'rgb(220, 220, 220)',
+				strokeColor: isDark ? mediumLight : mediumDark,
+				stateBorderColor: isDark ? light : dark, // New color for state boundaries when zoomed in
+				overlayColor: isDark ? 'rgba(0, 0, 0, 0.6)' : 'rgba(0, 0, 0, 0.5)', // Overlay color for non-selected features
+			},
+		},
+	};
+}

--- a/src/components/d3/utils/zoom.js
+++ b/src/components/d3/utils/zoom.js
@@ -185,6 +185,7 @@ export function handleOverlaysOnZoom({
 	activeLocationStack,
 	props,
 	svg,
+	STATUSES,
 }) {
 	if (event.transform.k < currentZoom) {
 		const COUNTY_THRESHOLD = 5.25;
@@ -192,10 +193,10 @@ export function handleOverlaysOnZoom({
 
 		// County overlay
 		if (
-			!!layers.countyOverlay.visible &&
+			layers.countyOverlay.status === STATUSES.IDLE &&
 			event.transform.k < COUNTY_THRESHOLD
 		) {
-			layers.countyOverlay.visible = false;
+			layers.countyOverlay.status = STATUSES.HIDDEN;
 
 			if (
 				['fips', 'county_fips'].some(
@@ -228,10 +229,13 @@ export function handleOverlaysOnZoom({
 		}
 
 		// State overlay
-		if (!!layers.stateOverlay.visible && event.transform.k < STATE_THRESHOLD) {
+		if (
+			!!layers.stateOverlay.status === STATUSES.IDLE &&
+			event.transform.k < STATE_THRESHOLD
+		) {
 			// Update visibility
-			layers.stateOverlay.visible = false;
-			layers.countyOverlay.visible = false;
+			layers.stateOverlay.status = STATUSES.HIDDEN;
+			layers.countyOverlay.status = STATUSES.HIDDEN;
 
 			// Remove overlay layers from DOM
 			svg.select('.stateOverlay-layer').remove();
@@ -253,6 +257,7 @@ export function updateLayerVisibility({
 	currentZoom,
 	svg,
 	createLegend,
+	STATUSES,
 }) {
 	// Track if visibility changed
 	let visibilityChanged = false;
@@ -265,12 +270,12 @@ export function updateLayerVisibility({
 			currentZoom >= layer.minZoom && currentZoom <= layer.maxZoom;
 
 		// Check if visibility changed
-		if (layer.visible !== shouldBeVisible) {
+		if (Boolean(layer.status === STATUSES.IDLE) && shouldBeVisible) {
 			visibilityChanged = true;
 		}
 
 		// Update visibility state
-		layer.visible = shouldBeVisible;
+		layer.status = shouldBeVisible ? STATUSES.IDLE : STATUSES.HIDDEN;
 
 		// Apply visibility to DOM
 		const layerElement = svg.select(`.${layerName}-layer`);

--- a/src/components/d3/utils/zoom.js
+++ b/src/components/d3/utils/zoom.js
@@ -7,12 +7,21 @@ import _debounce from 'lodash/debounce';
  * Sets up zoom behavior for the map
  * @param {Object} params - Parameters needed for zoom setup
  */
-export function setupZoom({ svg, MIN_ZOOM, MAX_ZOOM, handleZoom }) {
+export function setupZoom({
+	svg,
+	MIN_ZOOM,
+	MAX_ZOOM,
+	onZoom,
+	onZoomStart,
+	onZoomEnd,
+}) {
 	// Create zoom behavior
 	const zoom = d3
 		.zoom()
 		.scaleExtent([MIN_ZOOM, MAX_ZOOM]) // Min/max zoom levels
-		.on('zoom', handleZoom);
+		.on('start', onZoomStart)
+		.on('zoom', onZoom)
+		.on('end', onZoomEnd);
 
 	// Apply zoom to SVG
 	svg.call(zoom);
@@ -114,7 +123,7 @@ export const updateIconSize = _debounce(
 		// Calculate icon size: 4px at zoom 1, decreasing to 1px at zoom 22+
 		const minSize = 0.75;
 		const maxSize = 3;
-		const maxZoomRange = MAX_ZOOM / 2.3;
+		const maxZoomRange = MAX_ZOOM / 1.5;
 
 		// Calculate size based on zoom level (inverse relationship)
 		let iconSize;

--- a/src/components/d3/utils/zoom.js
+++ b/src/components/d3/utils/zoom.js
@@ -69,9 +69,13 @@ export function addZoomControls({ svg, width, resetZoom }) {
 		.attr('stroke', '#ccc')
 		.attr('rx', 3)
 		.attr('cursor', 'pointer')
-		.on('click', () => {
+		.on('click', (event) => {
+			event.stopPropagation();
 			const zoom = svg.__zoom__ || d3.zoom();
 			svg.transition().call(zoom.scaleBy, 0.75);
+		})
+		.on('dblclick', (event) => {
+			event.stopPropagation();
 		});
 
 	controls
@@ -137,17 +141,16 @@ export const updateIconSize = _debounce(
  */
 export const updateZoomLevel = _debounce(
 	(zoomLevel, MAX_ZOOM) => {
-		const minSize = 0;
-		const maxSize = 1;
+		const min = 0;
+		const max = 0.75;
 
 		// Calculate size based on zoom level (inverse relationship)
 		let zoomInversion;
 		if (zoomLevel >= MAX_ZOOM) {
-			zoomInversion = minSize;
+			zoomInversion = min;
 		} else {
 			// Linear interpolation between maxSize and minSize
-			zoomInversion =
-				maxSize - ((zoomLevel - 1) / (MAX_ZOOM - 1)) * (maxSize - minSize);
+			zoomInversion = max - ((zoomLevel - 1) / (MAX_ZOOM - 1)) * (max - min);
 		}
 
 		// Round to 2 decimal places
@@ -248,6 +251,7 @@ export function updateLayerVisibility({
 	// Show/hide layers based on zoom level
 	Object.keys(layers).forEach((layerName) => {
 		const layer = layers[layerName];
+
 		const shouldBeVisible =
 			currentZoom >= layer.minZoom && currentZoom <= layer.maxZoom;
 

--- a/src/components/d3/utils/zoom.js
+++ b/src/components/d3/utils/zoom.js
@@ -1,0 +1,276 @@
+// zoomUtils.js - Utilities for handling zoom functionality
+
+import * as d3 from 'd3';
+import _debounce from 'lodash/debounce';
+
+/**
+ * Sets up zoom behavior for the map
+ * @param {Object} params - Parameters needed for zoom setup
+ */
+export function setupZoom({ svg, MIN_ZOOM, MAX_ZOOM, handleZoom }) {
+	// Create zoom behavior
+	const zoom = d3
+		.zoom()
+		.scaleExtent([MIN_ZOOM, MAX_ZOOM]) // Min/max zoom levels
+		.on('zoom', handleZoom);
+
+	// Apply zoom to SVG
+	svg.call(zoom);
+
+	// Store the zoom behavior for later use
+	svg.__zoom__ = zoom;
+
+	// Initialize with no zoom
+	svg.call(zoom.transform, d3.zoomIdentity);
+}
+
+/**
+ * Adds zoom controls to the map
+ * @param {Object} params - Parameters needed for adding zoom controls
+ */
+export function addZoomControls({ svg, width, resetZoom }) {
+	// Add zoom in/out buttons
+	const controls = svg
+		.append('g')
+		.attr('class', 'zoom-controls')
+		.attr('transform', `translate(${width - 60}, 20)`);
+
+	// Zoom in button
+	controls
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 0)
+		.attr('width', 30)
+		.attr('height', 30)
+		.attr('fill', 'white')
+		.attr('stroke', '#ccc')
+		.attr('rx', 3)
+		.attr('cursor', 'pointer')
+		.on('click', () => {
+			const zoom = svg.__zoom__ || d3.zoom();
+			svg.transition().call(zoom.scaleBy, 1.5);
+		});
+
+	controls
+		.append('text')
+		.attr('x', 15)
+		.attr('y', 20)
+		.attr('text-anchor', 'middle')
+		.text('+');
+
+	// Zoom out button
+	controls
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 35)
+		.attr('width', 30)
+		.attr('height', 30)
+		.attr('fill', 'white')
+		.attr('stroke', '#ccc')
+		.attr('rx', 3)
+		.attr('cursor', 'pointer')
+		.on('click', () => {
+			const zoom = svg.__zoom__ || d3.zoom();
+			svg.transition().call(zoom.scaleBy, 0.75);
+		});
+
+	controls
+		.append('text')
+		.attr('x', 15)
+		.attr('y', 55)
+		.attr('text-anchor', 'middle')
+		.text('-');
+
+	// Reset button
+	controls
+		.append('rect')
+		.attr('x', 0)
+		.attr('y', 70)
+		.attr('width', 30)
+		.attr('height', 30)
+		.attr('fill', 'white')
+		.attr('stroke', '#ccc')
+		.attr('rx', 3)
+		.attr('cursor', 'pointer')
+		.on('click', resetZoom);
+
+	controls
+		.append('text')
+		.attr('x', 15)
+		.attr('y', 90)
+		.attr('text-anchor', 'middle')
+		.text('↺');
+}
+
+/**
+ * Updates icon size based on zoom level
+ */
+export const updateIconSize = _debounce(
+	(zoomLevel, MAX_ZOOM) => {
+		// Calculate icon size: 4px at zoom 1, decreasing to 1px at zoom 22+
+		const minSize = 0.75;
+		const maxSize = 3;
+		const maxZoomRange = MAX_ZOOM / 2.3;
+
+		// Calculate size based on zoom level (inverse relationship)
+		let iconSize;
+		if (zoomLevel >= maxZoomRange) {
+			iconSize = minSize;
+		} else {
+			// Linear interpolation between maxSize and minSize
+			iconSize =
+				maxSize - ((zoomLevel - 1) / (maxZoomRange - 1)) * (maxSize - minSize);
+		}
+
+		// Round to 2 decimal places
+		iconSize = Math.round(iconSize * 100) / 100;
+
+		// Set the CSS variable on the container
+		document.documentElement.style.setProperty('--icon-size', `${iconSize}px`);
+	},
+	100,
+	{ leading: true, trailing: true },
+);
+
+/**
+ * Updates zoom level CSS variable
+ */
+export const updateZoomLevel = _debounce(
+	(zoomLevel, MAX_ZOOM) => {
+		const minSize = 0;
+		const maxSize = 1;
+
+		// Calculate size based on zoom level (inverse relationship)
+		let zoomInversion;
+		if (zoomLevel >= MAX_ZOOM) {
+			zoomInversion = minSize;
+		} else {
+			// Linear interpolation between maxSize and minSize
+			zoomInversion =
+				maxSize - ((zoomLevel - 1) / (MAX_ZOOM - 1)) * (maxSize - minSize);
+		}
+
+		// Round to 2 decimal places
+		zoomInversion = Math.round(zoomInversion * 100) / 100;
+
+		// Set the CSS variable on the container
+		document.documentElement.style.setProperty(
+			'--zoom-inversion',
+			zoomInversion,
+		);
+	},
+	100,
+	{ leading: true, trailing: true },
+);
+
+/**
+ * Handles overlay visibility based on zoom level
+ */
+export function handleOverlaysOnZoom({
+	event,
+	currentZoom,
+	layers,
+	activeLocationStack,
+	props,
+	svg,
+}) {
+	if (event.transform.k < currentZoom) {
+		const COUNTY_THRESHOLD = 5.25;
+		const STATE_THRESHOLD = 1.25;
+
+		// County overlay
+		if (
+			!!layers.countyOverlay.visible &&
+			event.transform.k < COUNTY_THRESHOLD
+		) {
+			layers.countyOverlay.visible = false;
+
+			if (
+				['fips', 'county_fips'].some(
+					(s) =>
+						s in (activeLocationStack[activeLocationStack.length - 1] ?? {}),
+				)
+			) {
+				const stateIndex = activeLocationStack.findLastIndex(
+					(loc) => loc.type === 'state',
+				);
+				const inferredState = props.states.find(
+					(state) =>
+						state.state_iso ===
+						activeLocationStack[activeLocationStack.length - 1].data.state_iso,
+				);
+
+				activeLocationStack = activeLocationStack
+					.slice(0, stateIndex + 1)
+					.concat([
+						{
+							type: 'state',
+							name: inferredState.name,
+							data: inferredState,
+						},
+					]);
+			}
+
+			// Remove overlay layers from DOM
+			svg.select('.countyOverlay-layer').remove();
+		}
+
+		// State overlay
+		if (!!layers.stateOverlay.visible && event.transform.k < STATE_THRESHOLD) {
+			// Update visibility
+			layers.stateOverlay.visible = false;
+			layers.countyOverlay.visible = false;
+
+			// Remove overlay layers from DOM
+			svg.select('.stateOverlay-layer').remove();
+			svg.select('.countyOverlay-layer').remove();
+
+			// Clear the active location stack since we're zooming out
+			activeLocationStack = [];
+		}
+	}
+
+	return activeLocationStack;
+}
+
+/**
+ * Updates layer visibility based on zoom level
+ */
+export function updateLayerVisibility({
+	layers,
+	currentZoom,
+	svg,
+	createLegend,
+}) {
+	// Track if visibility changed
+	let visibilityChanged = false;
+
+	// Show/hide layers based on zoom level
+	Object.keys(layers).forEach((layerName) => {
+		const layer = layers[layerName];
+		const shouldBeVisible =
+			currentZoom >= layer.minZoom && currentZoom <= layer.maxZoom;
+
+		// Check if visibility changed
+		if (layer.visible !== shouldBeVisible) {
+			visibilityChanged = true;
+		}
+
+		// Update visibility state
+		layer.visible = shouldBeVisible;
+
+		// Apply visibility to DOM
+		const layerElement = svg.select(`.${layerName}-layer`);
+		if (!layerElement.empty()) {
+			layerElement.style('display', shouldBeVisible ? 'block' : 'none');
+		}
+	});
+
+	// Update legend if layer visibility changed
+	if (visibilityChanged) {
+		// Remove existing legend
+		svg.select('.legend').remove();
+		// Create new legend with appropriate scale
+		createLegend();
+	}
+}

--- a/src/pages/d3Route.vue
+++ b/src/pages/d3Route.vue
@@ -1,6 +1,6 @@
 <template>
 	<main>
-		<DataSourceMapD3 :counties="data.counties" :states="data.states" />
+		<DataSourceMapD3 v-bind="{ ...data }" />
 	</main>
 </template>
 
@@ -11,7 +11,7 @@ import axios from 'axios';
 
 const PDAP_DATA_SOURCE_SEARCH = import.meta.env.VITE_API_URL + '/map/locations';
 
-const data = ref([]);
+const data = ref({});
 const error = ref(undefined);
 
 onMounted(async () => {


### PR DESCRIPTION
See #27 

Adds the following:

- "Active" styling for states and counties on click.
    - The basis for this is an "active location" state, which will also be the basis for the sidebar.
- Locality point markers
    - These need some fine-tuning, as the lng/lat appears to be slightly off when projected onto this map projection.
- Zoom behavior, etc.


Issues still to resolve
- Some performance glitchiness
    - I think some of this can be resolved by splitting the localities data into two layers: with sources, and without sources. The localities with sources can be rendered at the current zoom level, then if we wait to render the ones without sources until zoomed in more tightly, we should hopefully be able to optimize that render such that we never get a huge render with all of the glitchiness we're seeing now.
- Loading UI
- Loading orchestration: Render the map once the states layer is done, then handle the other layers behind the scenes.
- Sidebar, etc.
- Tooltip text and formatting tweaks